### PR TITLE
Run controller pod with readonly root filesystem

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,6 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
+          readOnlyRootFilesystem: true
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,6 +77,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
The controller pod has two containers:
* kube-rbac-proxy
* manager

These containers should run with readonly root filesystem.

This fixes the kube-linter reported errors in https://github.com/redhat-appstudio/infra-deployments/actions/runs/9369177927/job/25842546983?pr=3798
```
...
"text": "container \"manager\" does not have a read-only root file system\nobject: mintmaker/mintmaker-controller-manager apps/v1, Kind=Deployment"
...
"text": "container \"kube-rbac-proxy\" does not have a read-only root file system\nobject: mintmaker/mintmaker-controller-manager apps/v1, Kind=Deployment"
...
```