### PR TITLE
Only handle new DependencyUpdateCheck CRs in mintmaker namespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -36,6 +37,7 @@ import (
 
 	mmv1alpha1 "github.com/konflux-ci/mintmaker/api/v1alpha1"
 	"github.com/konflux-ci/mintmaker/internal/controller"
+	. "github.com/konflux-ci/mintmaker/pkg/common"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
@@ -118,6 +120,9 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{MintMakerNamespaceName: {}},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/internal/controller/suite_util_test.go
+++ b/internal/controller/suite_util_test.go
@@ -252,15 +252,21 @@ func deleteComponent(resourceKey types.NamespacedName) {
 	}, timeout, interval).Should(BeTrue())
 }
 
-func createDependencyUpdateCheck(resourceKey types.NamespacedName) {
+func createDependencyUpdateCheck(resourceKey types.NamespacedName, processed bool) {
+	annotations := map[string]string{}
+	if processed {
+		annotations[MintMakerProcessedAnnotationName] = "true"
+	}
+
 	dependencyUpdateCheck := &mmv1alpha1.DependencyUpdateCheck{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "appstudio.redhat.com/v1alpha1",
 			Kind:       "DependencyUpdateCheck",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceKey.Name,
-			Namespace: resourceKey.Namespace,
+			Name:        resourceKey.Name,
+			Namespace:   resourceKey.Namespace,
+			Annotations: annotations,
 		},
 		Spec: mmv1alpha1.DependencyUpdateCheckSpec{},
 	}

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -2,6 +2,8 @@ package common
 
 const (
 	MintMakerNamespaceName = "mintmaker"
+	//
+	MintMakerProcessedAnnotationName = "mintmaker.appstudio.redhat.com/processed"
 	// Pipelines as Code GitHub appliaction configuration secret name.
 	// The secret is located in Build Service namespace.
 	PipelinesAsCodeGitHubAppSecretName = "pipelines-as-code-secret"


### PR DESCRIPTION
* The controller only watches for CRs created in mintmaker namespace
* The controller doesn't process CRs which have been processed before, when a CR is processed, an annotation will be added to the CR.

CWFHEALTH-3083