### PR TITLE
Increase memory allocation for manager to prevent OOMKilled issue

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -95,9 +95,9 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 256Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
The controller manager pod was consistently crashing due to being OOMKilled. Increased the memory allocation to ensure the pod has sufficient resources to operate without running out of memory.