### PR TITLE
Update client to cluster-scoped

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,7 +29,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -37,7 +36,6 @@ import (
 
 	mmv1alpha1 "github.com/konflux-ci/mintmaker/api/v1alpha1"
 	"github.com/konflux-ci/mintmaker/internal/controller"
-	. "github.com/konflux-ci/mintmaker/pkg/common"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
@@ -120,9 +118,6 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
-		Cache: cache.Options{
-			DefaultNamespaces: map[string]cache.Config{MintMakerNamespaceName: {}},
-		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -70,6 +70,11 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 	log := ctrllog.FromContext(ctx).WithName("DependencyUpdateCheckController")
 	ctx = ctrllog.IntoContext(ctx, log)
 
+	// Ignore CRs that are not from the mintmaker namespace
+	if req.Namespace != MintMakerNamespaceName {
+		return ctrl.Result{}, nil
+	}
+
 	dependencyupdatecheck := &mmv1alpha1.DependencyUpdateCheck{}
 	err := r.client.Get(ctx, req.NamespacedName, dependencyupdatecheck)
 	if err != nil {

--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -103,6 +103,14 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 		log.Error(err, "failed to list Components")
 		return ctrl.Result{}, err
 	}
+
+	numComponents := len(componentList.Items)
+	log.Info("found components", "components", numComponents)
+
+	if numComponents == 0 {
+		return ctrl.Result{}, nil
+	}
+
 	var scmComponents []*git.ScmComponent
 	for _, component := range componentList.Items {
 		gitProvider, err := getGitProvider(component)
@@ -126,6 +134,10 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 		if len(newTasks) > 0 {
 			tasks = append(tasks, newTasks...)
 		}
+	}
+
+	if len(tasks) == 0 {
+		return ctrl.Result{}, nil
 	}
 
 	log.Info("executing renovate tasks", "tasks", len(tasks))


### PR DESCRIPTION
The controller needs to list components in cluster, so the client can't be namespace scoped.