### PR TITLE
Allow component to have the capability to disable Mintmaker

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,11 +63,11 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 
-	applicationApiDepVersion := "v0.0.0-20240326104708-c647c0bdcda5"
+	applicationApiDepVersion := "v0.0.0-20240527211352-be061932d497"
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("../..", "config", "crd", "bases"),
-			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "redhat-appstudio", "application-api@"+applicationApiDepVersion, "config", "crd", "bases"),
+			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "konflux-ci", "application-api@"+applicationApiDepVersion, "config", "crd", "bases"),
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/internal/controller/suite_util_test.go
+++ b/internal/controller/suite_util_test.go
@@ -32,8 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gh "github.com/google/go-github/v45/github"
-	mmv1alpha1 "github.com/konflux-ci/mintmaker/api/v1alpha1"
 	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	mmv1alpha1 "github.com/konflux-ci/mintmaker/api/v1alpha1"
 
 	. "github.com/konflux-ci/mintmaker/pkg/common"
 	"github.com/konflux-ci/mintmaker/pkg/git/github"
@@ -250,6 +250,21 @@ func deleteComponent(resourceKey types.NamespacedName) {
 	Eventually(func() bool {
 		return k8sErrors.IsNotFound(k8sClient.Get(ctx, resourceKey, component))
 	}, timeout, interval).Should(BeTrue())
+}
+
+func disableComponentMintmaker(resourceKey types.NamespacedName) {
+	component := &appstudiov1alpha1.Component{}
+	Expect(k8sClient.Get(ctx, resourceKey, component)).Should(Succeed())
+
+	if component.Annotations == nil {
+		component.Annotations = make(map[string]string)
+	}
+
+	component.Annotations[MintMakerDisabledAnnotationName] = "true"
+
+	Expect(k8sClient.Update(ctx, component)).Should(Succeed())
+
+	getComponent(resourceKey)
 }
 
 func createDependencyUpdateCheck(resourceKey types.NamespacedName, processed bool) {

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -2,8 +2,10 @@ package common
 
 const (
 	MintMakerNamespaceName = "mintmaker"
-	//
+	// Mintmaker will add processed annotation when the dependencyupdatecheck is processed by controller
 	MintMakerProcessedAnnotationName = "mintmaker.appstudio.redhat.com/processed"
+	// Mintmaker can be disabled by disabled annotation in component
+	MintMakerDisabledAnnotationName = "mintmaker.appstudio.redhat.com/disabled"
 	// Pipelines as Code GitHub appliaction configuration secret name.
 	// The secret is located in Build Service namespace.
 	PipelinesAsCodeGitHubAppSecretName = "pipelines-as-code-secret"


### PR DESCRIPTION
This update allows component owners to disable Mintmaker for their components. To do this, add the following annotation to the component:

```
mintmaker.appstudio.redhat.com/disabled: true
```

CWFHEALTH-3162