### PR TITLE
Fix incorrect mintmaker processed annotation check

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -84,7 +84,7 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	// If the DependencyUpdateCheck has been handled before, skip it
-	if _, processed := dependencyupdatecheck.Annotations[MintMakerProcessedAnnotationName]; processed {
+	if value, exists := dependencyupdatecheck.Annotations[MintMakerProcessedAnnotationName]; exists && value == "true" {
 		log.Info(fmt.Sprintf("DependencyUpdateCheck has been processed: %v", req.NamespacedName))
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
Previously, the code only checked for the existence of the annotation, but did not verify its value.