### PR TITLE
Use main branch when branch is missing for gitlab components

### DIFF
--- a/pkg/renovate/basicauth.go
+++ b/pkg/renovate/basicauth.go
@@ -65,11 +65,17 @@ func (g BasicAuthTaskProvider) GetNewTasks(ctx context.Context, components []*gi
 						}
 						// Step 6
 						if !AddNewRepoToTasksOnTheSameHostsWithSameCredentials(tasksOnHost, component, creds) {
+							branch := component.Branch()
+							// When platform is gitlab and branch is missing, use "main" branch
+							// TODO: check Gitlab to determine the default branch
+							if component.Platform() == "gitlab" && branch == git.InternalDefaultBranch {
+								branch = "main"
+							}
 							// Step 7
 							tasksOnHost = append(tasksOnHost, NewBasicAuthTask(platform, host, endpoint, creds, []*Repository{
 								{
 									Repository:   component.Repository(),
-									BaseBranches: []string{component.Branch()},
+									BaseBranches: []string{branch},
 								},
 							}))
 						}

--- a/pkg/renovate/basicauth_test.go
+++ b/pkg/renovate/basicauth_test.go
@@ -152,6 +152,27 @@ func TestNewTasks(t *testing.T) {
 				}),
 			},
 		},
+		{
+			name:            "GitLab component should use main branch if revision is missing",
+			credentialsFunc: StaticCredentialsFunc,
+			components: []*git.ScmComponent{
+				ignoreError(
+					git.NewScmComponent(
+						"gitlab",
+						"https://gitlab.com/umbrellacorp/devfile-sample-go-basic",
+						"",
+						"devfile-sample-go-basic",
+						"umbrellacorp-tenant")).(*git.ScmComponent),
+			},
+			expected: []*Task{
+				NewBasicAuthTask("gitlab", "gitlab.com", "https://gitlab.com/api/v4/", staticCredentials, []*Repository{
+					{
+						Repository:   "umbrellacorp/devfile-sample-go-basic",
+						BaseBranches: []string{"main"},
+					},
+				}),
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
If revision is not explicitly specified for a GitLab component, the 'main' branch will be used as a short-term solution. In the future, we should check GitLab to determine the default branch.