### PR TITLE
Add renovate config and fix errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence, these
 # owners will be requested for review when someone opens a
 # pull request.
-*  @gnaponie @qixiang @staticf0x @FernandesMF @nvtnlucie
+*  @gnaponie @qixiang @staticf0x @FernandesMF @nvtnlucie @querti

--- a/config/renovate/kustomization.yaml
+++ b/config/renovate/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+- name: renovate-config
+  files:
+  - renovate.json
+  options:
+    disableNameSuffixHash: true

--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":gitSignOff",
+    ":disableDependencyDashboard"
+  ],
+  "ignorePresets": [":dependencyDashboard"],
+  "onboarding": false,
+  "requireConfig": "optional",
+  "platformCommit": true,
+  "autodiscover": false,
+  "enabledManagers": ["tekton", "dockerfile", "rpm", "git-submodules"],
+  "tekton": {
+    "fileMatch": ["\\.yaml$","\\.yml$"],
+    "includePaths": [".tekton/**"],
+    "packageRules": [
+      {
+        "matchPackagePatterns": [
+          "^quay.io/redhat-appstudio-tekton-catalog/",
+          "^quay.io/konflux-ci/tekton-catalog/"
+        ],
+        "enabled": true,
+        "groupName": "Konflux references",
+        "branchPrefix": "konflux/references/",
+        "branchTopic": "{{baseBranch}}",
+        "commitMessageTopic": "Konflux references",
+        "semanticCommits": "enabled",
+        "prFooter": "To execute skipped test pipelines write comment `/ok-to-test`",
+        "prBodyColumns": [
+          "Package",
+          "Change",
+          "Notes"
+        ],
+        "prBodyDefinitions": { "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '^quay.io/redhat-appstudio-tekton-catalog/task-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}" },
+        "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
+        "recreateWhen": "always",
+        "rebaseWhen": "behind-base-branch"
+      }
+    ]
+  },
+  "git-submodules": {
+    "enabled": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "recreateWhen": "always",
+    "rebaseWhen": "behind-base-branch",
+    "branchTopic": "lock-file-maintenance",
+    "schedule": ["at any time"]
+  },
+  "forkProcessing": "enabled",
+  "dependencyDashboard": false
+}


### PR DESCRIPTION
The new directory contains the renovate config and a kustomization file to create a configmap out of it. The git path to these resources is expected to be referenced in mintmaker infra-deployments definitions. Introducing renovate config changes can be done by changing the commit SHA in mintmaker infra-deployments.

I haven't split the config into presets. The main reason is that it uses another version control system, which means that we would need to maintain versioning for the global config as well as for all of its presets. This makes things needlesly complicated and doesn't provide any benefit. Secondly, the main reason for using presets is reusing the configuration by other users. I suggest to refrain from arbitrarily splitting the config file until we know which parts other people want to reuse.

The config itself was fixed to not contain any errors and warnings. List of changes:
- Remove outer quotes from prBodyDefinitions, as this field expects a JSON object. This is the only error in the config
- Change the branchName field to branchPrefix and branchTopic. The branchName field is deprecated.
- Change '"rebaseStalePrs": true' to '"rebaseWhen": "behind-base-branch"'. This change was suggested as a renovate migration.

Refers to CWFHEALTH-3210, CWFHEALTH-3206