### PR TITLE
renovate config: fix tekton task migration doc url

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -32,7 +32,7 @@
           "Change",
           "Notes"
         ],
-        "prBodyDefinitions": { "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '^quay.io/redhat-appstudio-tekton-catalog/task-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}" },
+        "prBodyDefinitions": { "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '^quay.io/(redhat-appstudio-tekton-catalog|konflux-ci/tekton-catalog)/task-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}" },
         "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
         "recreateWhen": "always",
         "rebaseWhen": "behind-base-branch"


### PR DESCRIPTION
The generated tekton task migration doc URL was incorrect when task is using the new konflux-ci repository. This change updates the URL pattern to correctly handle both redhat-appstudio-tekton-catalog and konflux-ci/tekton-catalog repositories.

CWFHEALTH-3267