### PR TITLE
Enable custom regex manager

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -10,7 +10,7 @@
   "requireConfig": "optional",
   "platformCommit": true,
   "autodiscover": false,
-  "enabledManagers": ["tekton", "dockerfile", "rpm", "git-submodules"],
+  "enabledManagers": ["tekton", "dockerfile", "rpm", "git-submodules", "regex"],
   "tekton": {
     "fileMatch": ["\\.yaml$","\\.yml$"],
     "includePaths": [".tekton/**"],


### PR DESCRIPTION
This commit enables creation of custom regex managers. The manager does nothing on its own, onboarded users need to include `customManagers` section in their config. It was tested using following configuration:

`customManagers:
  - customType: regex
    fileMatch: 
      - Dockerfile
    matchStrings:
      - "ENV YARN_VERSION=(?<currentValue>.*?)\\n"
    depNameTemplate: yarn
    datasourceTemplate: npm`

If no configuration is found, regex manager is simply ignored. Ill follow up with a documentation update as well.