### PR TITLE
Enable Kubernetes managers

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -10,7 +10,9 @@
   "requireConfig": "optional",
   "platformCommit": true,
   "autodiscover": false,
-  "enabledManagers": ["tekton", "dockerfile", "rpm", "git-submodules", "regex"],
+  "enabledManagers": ["tekton", "dockerfile", "rpm", "git-submodules", "regex", "argocd", "crossplane",
+                      "fleet", "flux", "helm-requirements", "helm-values", "helmfile", "helmsman", "helmv3",
+                      "jsonnet-bundler", "kubernetes", "kustomize"],
   "tekton": {
     "fileMatch": ["\\.yaml$","\\.yml$"],
     "includePaths": [".tekton/**"],
@@ -47,6 +49,54 @@
     "rebaseWhen": "behind-base-branch",
     "branchTopic": "lock-file-maintenance",
     "schedule": ["at any time"]
+  },
+  "argocd": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "crossplane": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "fleet": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "flux": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "helm-requirements": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "helm-values": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "helmfile": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "helmsman": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "helmv3": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "jsonnet-bundler": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "kubernetes": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "kustomize": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
   },
   "forkProcessing": "enabled",
   "dependencyDashboard": false

--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -41,7 +41,9 @@
     ]
   },
   "git-submodules": {
-    "enabled": true
+    "enabled": true,
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
   },
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
Enable managers as grouped on this page[1]. The mintmaker image should have all the required dependencies to run these managers. Also, since they only analyze yaml/json, there shouldn't be any "hidden" dependencies either.

The new managers will use a new branch format, from renovate/\<dep name\> to konflux/mintmaker/\<branch\>/\<dep name\>. Branch name is included to resolve branch conflicts if multiple branches are onboarded onto Konflux. Mintmaker name is added so that end users can more easily understand where the PR/MR came from.

Refers to CWFHEALTH-3178

[1] https://docs.renovatebot.com/modules/manager/