### PR TITLE
Create correct branch name in tekton manager without using branchName

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -47,7 +47,11 @@
         ],
         "enabled": true,
         "groupName": "Konflux references",
-        "branchName": "konflux/references/{{baseBranch}}",
+        "branchPrefix": "konflux/references/",
+        "group": {
+          "branchTopic": "{{{baseBranch}}}",
+          "commitMessageTopic": "{{{groupName}}}"
+        },
         "commitMessageTopic": "Konflux references",
         "semanticCommits": "enabled",
         "prFooter": "To execute skipped test pipelines write comment `/ok-to-test`",


### PR DESCRIPTION
Since the branchName config option is deprecated, I previously tried to change it to branchPrefix + branchTopic[1]. However, this has created an unexpected branch name in the tekton manager [2]. Expected name: 'konflux/references/{basebranch}', actual name: 'konflux/references/konflux-references'. Turns out, the culprit was the config option "groupName". If this option is set, it 'activates' another option, "group" [3]. "group" changes "branchTopic" to "groupSlug" by default, which explains why the suffix of the branch name is "konflux-references". Setting "branchTopic" manually has no effect, since since the value gets overwritten by the value set in "group". Fix the issue by manually configuring "group" to set "branchTopic" to baseBranch instead of groupSlug.

Refers to CWFHEALTH-3266

[1] https://github.com/konflux-ci/mintmaker/pull/32
[2] https://github.com/konflux-ci/buildah-container/pull/39
[3] https://docs.renovatebot.com/configuration-options/#group