### PR TITLE
Enable managers from category No category

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -16,7 +16,6 @@
     "tekton",
     "dockerfile",
     "rpm",
-    "git-submodules",
     "regex",
     "argocd",
     "crossplane",
@@ -29,7 +28,16 @@
     "helmv3",
     "jsonnet-bundler",
     "kubernetes",
-    "kustomize"
+    "kustomize",
+    "asdf",
+    "fvm",
+    "git-submodules",
+    "hermit",
+    "homebrew",
+    "nix",
+    "osgi",
+    "pre-commit",
+    "vendir"
   ],
   "tekton": {
     "fileMatch": [
@@ -133,6 +141,40 @@
     "branchPrefix": "konflux/mintmaker/"
   },
   "kustomize": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "asdf": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "fvm": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "hermit": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "homebrew": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "nix": {
+    "enabled": true,
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "osgi": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "pre-commit": {
+    "enabled": true,
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "vendir": {
     "additionalBranchPrefix": "{{baseBranch}}/",
     "branchPrefix": "konflux/mintmaker/"
   },


### PR DESCRIPTION
Following commit enables managers asdf, fvm, hermit, homebrew, nix, osgi, pre-commit, vendir. There are 3 managers left in this category (copier, gleam, mise), which are currently not available and require a rebase of renovate project.
A [Google sheet ](https://docs.google.com/spreadsheets/d/15t9WVpGhSl-QRFzFPnGYMh4BOPZbx_3FpUbfxk4FVZY/edit?usp=sharing) shows details of dependencies of each manager. Some managers require to set an environment variable with a Github token. The controller code should be sufficient to provide auth for GITHUB_COM_TOKEN, I was not able to test locally if it works for the HERMIT_GITHUB_TOKEN as well.

https://github.com/konflux-ci/mintmaker-renovate-image/pull/50 Must be merged together with this change.
Closes CWFHEALTH-3187.