### PR TITLE
Merge registry pull secrets and mount them to the job pod

### DIFF
--- a/pkg/renovate/job.go
+++ b/pkg/renovate/job.go
@@ -344,7 +344,7 @@ func (j *JobCoordinator) Execute(ctx context.Context, tasks []*Task) error {
 	}
 	log.Info("renovate job created", "jobname", job.Name, "tasks", len(tasks))
 
-	// Set ownership so all resources get deleted once the job finishes
+	// Set ownership so all resources get deleted once the job is deleted
 	if err := controllerutil.SetOwnerReference(job, secret, j.scheme); err != nil {
 		return err
 	}


### PR DESCRIPTION
One caveat is that the newly created secret cannot be created as base64 encoded string and I don't know why. It works with plain text. It's this line:
```go
encodedMergedConfig := base64.StdEncoding.EncodeToString(mergedConfigJson)
```
