### PR TITLE
Enable inheritConfig

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -10,6 +10,7 @@
   ],
   "onboarding": false,
   "requireConfig": "optional",
+  "inheritConfig": true,
   "platformCommit": true,
   "autodiscover": false,
   "enabledManagers": [


### PR DESCRIPTION
Add config option to enable inhereted config[1]. If enabled, renovate will look for organization-scoped configuration file. The file is expected to be located in repository {{parentOrg}}/renovate-config and be named org-inherited-config.json (default values set by renovate). The file not existing does not result in an error.

[1] https://docs.renovatebot.com/config-overview/#inherited-config

Refers to CLOUDDST-24240