### PR TITLE
Enable rpm-lockfile as allowedPostUpgradeCommands

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -180,5 +180,6 @@
     "branchPrefix": "konflux/mintmaker/"
   },
   "forkProcessing": "enabled",
+  "allowedPostUpgradeCommands": ["^rpm-lockfile-prototype rpms.in.yaml$"],
   "dependencyDashboard": false
 }


### PR DESCRIPTION
Some teams would like to run the rpm-lockfile script as a post-upgrade command. To allow them to do so, we need to add this configuration option.
See CWFHEALTH-3405 for more context on this.

ref: CWFHEALTH-3405