### PR TITLE
Fix unit tests

### DIFF
--- a/pkg/renovate/job.go
+++ b/pkg/renovate/job.go
@@ -353,11 +353,13 @@ func (j *JobCoordinator) Execute(ctx context.Context, tasks []*Task) error {
 		return err
 	}
 
-	if err := controllerutil.SetOwnerReference(job, registry_secret, j.scheme); err != nil {
-		return err
-	}
-	if err := j.client.Update(ctx, registry_secret); err != nil {
-		return err
+	if registry_secret != nil {
+		if err := controllerutil.SetOwnerReference(job, registry_secret, j.scheme); err != nil {
+			return err
+		}
+		if err := j.client.Update(ctx, registry_secret); err != nil {
+			return err
+		}
 	}
 
 	if err := controllerutil.SetOwnerReference(job, configMap, j.scheme); err != nil {


### PR DESCRIPTION
Due to a recent change, unit tests were failing with a null pointer dereference error. Fix the issue by checking if registry_secret is not nil.