### PR TITLE
Enable managers from Terraform category

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -38,7 +38,12 @@
     "nix",
     "osgi",
     "pre-commit",
-    "vendir"
+    "vendir",
+    "terraform",
+    "terraform-version",
+    "terragrunt",
+    "terragrunt-version",
+    "tflint-plugin"
   ],
   "tekton": {
     "fileMatch": [
@@ -176,6 +181,26 @@
     "branchPrefix": "konflux/mintmaker/"
   },
   "vendir": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "terraform": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "terraform-version": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "terragrunt": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "terragrunt-version": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "tflint-plugin": {
     "additionalBranchPrefix": "{{baseBranch}}/",
     "branchPrefix": "konflux/mintmaker/"
   },


### PR DESCRIPTION
Enables following managers: terraform, terragrunt, terraform-version, terragrunt-version, tflint-plugin. Every manager was part of Renovate for quite some time now, hence they do not need any special config and work well from the start. Here is my [testing spreadsheet](https://docs.google.com/spreadsheets/d/15t9WVpGhSl-QRFzFPnGYMh4BOPZbx_3FpUbfxk4FVZY/edit?usp=sharing) which was not theoretically even needed :).

Documentation update: prepared [here](https://gitlab.cee.redhat.com/lnovotna/users/-/commit/efa20d3acff0bef4efedb4dbd0fd96b29138603a)