### PR TITLE
Renovate config updates

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -17,7 +17,7 @@
     "tekton",
     "dockerfile",
     "rpm",
-    "regex",
+    "custom.regex",
     "argocd",
     "crossplane",
     "fleet",

--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -13,6 +13,9 @@
   "inheritConfig": true,
   "platformCommit": true,
   "autodiscover": false,
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
   "enabledManagers": [
     "tekton",
     "dockerfile",


### PR DESCRIPTION
1. Migrate 'regex' manager to 'custom.regex'
2. Disable 'vulnerabilityAlerts' feature
     This is a feature of using GitHub's Vulnerability Alerts (Dependabot) to customize PRs, it's enabled by default. It requires additional steps to make it work from repository admins, if the necessary setup if missing from the repository side, Renovate can open issues to repository with the warnings, since we have no plan to support this, just disable it from global config.
     https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts