### PR TITLE
Enable python managers in renovate config

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -46,7 +46,16 @@
     "terraform-version",
     "terragrunt",
     "terragrunt-version",
-    "tflint-plugin"
+    "tflint-plugin",
+    "pep621",
+    "pip-compile",
+    "pip_requirements",
+    "pip_setup",
+    "pipenv",
+    "poetry",
+    "pyenv",
+    "runtime-version",
+    "setup-cfg"
   ],
   "tekton": {
     "fileMatch": [
@@ -204,6 +213,42 @@
     "branchPrefix": "konflux/mintmaker/"
   },
   "tflint-plugin": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "pep621": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "pip-compile": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "pip_requirements": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "pip_setup": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "pipenv": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "poetry": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "pyenv": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "runtime-version": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "setup-cfg": {
     "additionalBranchPrefix": "{{baseBranch}}/",
     "branchPrefix": "konflux/mintmaker/"
   },


### PR DESCRIPTION
This commit enables the Renovate managers in the 'python' category.

The manager 'pep723' is currently not supported, in spite of Renovate docs listing it, so  I'm leaving it aside.

### Testing remarks
I made a quick testing repository with dependencies for each manager and verified the managers were enabled as desired with this new config:
```
DEBUG: Matched 1 file(s) for manager pep621: pyproject.toml (repository=FernandesMF/python_managers_test)
DEBUG: Matched 1 file(s) for manager pip-compile: pip-compile.txt (repository=FernandesMF/python_managers_test)
DEBUG: Matched 1 file(s) for manager pip_requirements: pip-requirements.txt (repository=FernandesMF/python_managers_test)
DEBUG: Matched 1 file(s) for manager pip_setup: pip-setup.py (repository=FernandesMF/python_managers_test)
DEBUG: Matched 1 file(s) for manager pipenv: Pipfile (repository=FernandesMF/python_managers_test)
DEBUG: Matched 2 file(s) for manager poetry: pyproject.toml, pyproject_poetry.toml (repository=FernandesMF/python_managers_test)
DEBUG: Matched 1 file(s) for manager pyenv: .python-version (repository=FernandesMF/python_managers_test)
DEBUG: Matched 1 file(s) for manager runtime-version: runtime.txt (repository=FernandesMF/python_managers_test)
DEBUG: Matched 1 file(s) for manager setup-cfg: setup.cfg (repository=FernandesMF/python_managers_test)
```

Weirdly,  the `pep723` manager resulted in this error:
```
Invalid configuration option: pep723, The following managers configured in enabledManagers are not supported: \"pep723\"
```
and it made Renovate quit without running the other managers, so I'm not enabling it.