### PR TITLE
Introduce PipelineRun utils

### DIFF
--- a/pkg/tekton/utils.go
+++ b/pkg/tekton/utils.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tekton
+
+import (
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// hasPipelineSucceeded returns a boolean indicating whether the PipelineRun succeeded or not.
+// If the object passed to this function is not a PipelineRun, the function will return false.
+func hasPipelineSucceeded(object client.Object) bool {
+	if pipelineRun, ok := object.(*tektonv1.PipelineRun); ok {
+		return !pipelineRun.Status.GetCondition(apis.ConditionSucceeded).IsUnknown()
+	}
+
+	return false
+}

--- a/pkg/tekton/utils/pipeline_run_builder.go
+++ b/pkg/tekton/utils/pipeline_run_builder.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"unicode"
+
+	"github.com/hashicorp/go-multierror"
+	libhandler "github.com/operator-framework/operator-lib/handler"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type PipelineRunBuilder struct {
+	err         *multierror.Error
+	pipelineRun *tektonv1.PipelineRun
+}
+
+// NewPipelineRunBuilder initializes a new PipelineRunBuilder with the given name prefix and namespace.
+// It sets the name of the PipelineRun to be generated with the provided prefix and sets its namespace.
+func NewPipelineRunBuilder(namePrefix, namespace string) *PipelineRunBuilder {
+	return &PipelineRunBuilder{
+		pipelineRun: &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: namePrefix + "-",
+				Namespace:    namespace,
+			},
+			Spec: tektonv1.PipelineRunSpec{},
+		},
+	}
+}
+
+// Build returns the constructed PipelineRun and any accumulated error.
+func (b *PipelineRunBuilder) Build() (*tektonv1.PipelineRun, error) {
+	return b.pipelineRun, b.err.ErrorOrNil()
+}
+
+// WithAnnotations appends or updates annotations to the PipelineRun's metadata.
+// If the PipelineRun does not have existing annotations, it initializes them before adding.
+func (b *PipelineRunBuilder) WithAnnotations(annotations map[string]string) *PipelineRunBuilder {
+	if b.pipelineRun.ObjectMeta.Annotations == nil {
+		b.pipelineRun.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	for key, value := range annotations {
+		b.pipelineRun.ObjectMeta.Annotations[key] = value
+	}
+
+	return b
+}
+
+// WithFinalizer adds the given finalizer to the PipelineRun's metadata.
+func (b *PipelineRunBuilder) WithFinalizer(finalizer string) *PipelineRunBuilder {
+	controllerutil.AddFinalizer(b.pipelineRun, finalizer)
+
+	return b
+}
+
+// WithLabels appends or updates labels to the PipelineRun's metadata.
+// If the PipelineRun does not have existing labels, it initializes them before adding.
+func (b *PipelineRunBuilder) WithLabels(labels map[string]string) *PipelineRunBuilder {
+	if b.pipelineRun.ObjectMeta.Labels == nil {
+		b.pipelineRun.ObjectMeta.Labels = make(map[string]string)
+	}
+
+	for key, value := range labels {
+		b.pipelineRun.ObjectMeta.Labels[key] = value
+	}
+
+	return b
+}
+
+// WithObjectReferences constructs tektonv1.Param entries for each of the provided client.Objects.
+// Each param name is derived from the object's Kind (with the first letter made lowercase) and
+// the value is a combination of the object's Namespace and Name.
+func (b *PipelineRunBuilder) WithObjectReferences(objects ...client.Object) *PipelineRunBuilder {
+	for _, obj := range objects {
+		name := []rune(obj.GetObjectKind().GroupVersionKind().Kind)
+		name[0] = unicode.ToLower(name[0])
+
+		b.WithParams(tektonv1.Param{
+			Name: string(name),
+			Value: tektonv1.ParamValue{
+				Type:      tektonv1.ParamTypeString,
+				StringVal: obj.GetNamespace() + "/" + obj.GetName(),
+			},
+		})
+	}
+
+	return b
+}
+
+// WithObjectSpecsAsJson constructs tektonv1.Param entries for the Spec field of each of the provided client.Objects.
+// Each param name is derived from the object's Kind (with the first letter made lowercase).
+// The value for each param is the JSON representation of the object's Spec.
+// If an error occurs during extraction or serialization, it's accumulated in the builder's err field using multierror.
+func (b *PipelineRunBuilder) WithObjectSpecsAsJson(objects ...client.Object) *PipelineRunBuilder {
+	for _, obj := range objects {
+		name := []rune(obj.GetObjectKind().GroupVersionKind().Kind)
+		name[0] = unicode.ToLower(name[0])
+
+		value := reflect.ValueOf(obj).Elem().FieldByName("Spec")
+		if !value.IsValid() {
+			b.err = multierror.Append(b.err, fmt.Errorf("failed to extract spec for object: %s", string(name)))
+			continue
+		}
+
+		jsonData, err := json.Marshal(value.Interface())
+		if err != nil {
+			b.err = multierror.Append(b.err, fmt.Errorf("failed to serialize spec of object %s to JSON: %v", string(name), err))
+			continue
+		}
+
+		b.WithParams(tektonv1.Param{
+			Name: string(name),
+			Value: tektonv1.ParamValue{
+				Type:      tektonv1.ParamTypeString,
+				StringVal: string(jsonData),
+			},
+		})
+	}
+
+	return b
+}
+
+// WithOwner sets the given client.Object as the owner of the PipelineRun.
+// It also adds the ReleaseFinalizer to the PipelineRun.
+func (b *PipelineRunBuilder) WithOwner(object client.Object) *PipelineRunBuilder {
+	if err := libhandler.SetOwnerAnnotations(object, b.pipelineRun); err != nil {
+		b.err = multierror.Append(b.err, fmt.Errorf("failed to set owner annotations: %v", err))
+		return b
+	}
+
+	return b
+}
+
+// WithParams appends the provided params to the PipelineRun's spec.
+func (b *PipelineRunBuilder) WithParams(params ...tektonv1.Param) *PipelineRunBuilder {
+	if b.pipelineRun.Spec.Params == nil {
+		b.pipelineRun.Spec.Params = make([]tektonv1.Param, 0)
+	}
+
+	b.pipelineRun.Spec.Params = append(b.pipelineRun.Spec.Params, params...)
+
+	return b
+}
+
+// WithServiceAccount sets the ServiceAccountName for the PipelineRun's TaskRunTemplate.
+func (b *PipelineRunBuilder) WithServiceAccount(serviceAccount string) *PipelineRunBuilder {
+	b.pipelineRun.Spec.TaskRunTemplate.ServiceAccountName = serviceAccount
+
+	return b
+}
+
+// WithTimeouts sets the Timeouts for the PipelineRun.
+func (b *PipelineRunBuilder) WithTimeouts(timeouts, defaultTimeouts *tektonv1.TimeoutFields) *PipelineRunBuilder {
+	if timeouts == nil || *timeouts == (tektonv1.TimeoutFields{}) {
+		b.pipelineRun.Spec.Timeouts = defaultTimeouts
+	} else {
+		b.pipelineRun.Spec.Timeouts = timeouts
+	}
+
+	return b
+}

--- a/pkg/tekton/utils/pipeline_run_builder_test.go
+++ b/pkg/tekton/utils/pipeline_run_builder_test.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-multierror"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
+var _ = Describe("PipelineRun builder", func() {
+
+	When("NewPipelineRunBuilder method is called", func() {
+		var (
+			namePrefix = "testPrefix"
+			namespace  = "testNamespace"
+			builder    *PipelineRunBuilder
+		)
+
+		BeforeEach(func() {
+			builder = NewPipelineRunBuilder(namePrefix, namespace)
+		})
+
+		It("should return a new PipelineRunBuilder instance", func() {
+			Expect(builder).To(Not(BeNil()))
+		})
+
+		It("should set the correct GenerateName in the returned PipelineRunBuilder instance", func() {
+			Expect(builder.pipelineRun.ObjectMeta.GenerateName).To(Equal(namePrefix + "-"))
+		})
+
+		It("should set the correct Namespace in the returned PipelineRunBuilder instance", func() {
+			Expect(builder.pipelineRun.ObjectMeta.Namespace).To(Equal(namespace))
+		})
+
+		It("should initialize an empty PipelineRunSpec", func() {
+			Expect(builder.pipelineRun.Spec).To(Equal(tektonv1.PipelineRunSpec{}))
+		})
+	})
+
+	When("Build method is called", func() {
+		It("should return the constructed PipelineRun if there are no errors", func() {
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			pr, err := builder.Build()
+			Expect(pr).To(Not(BeNil()))
+			Expect(err).To(BeNil())
+		})
+
+		It("should return the accumulated errors", func() {
+			builder := &PipelineRunBuilder{
+				err: multierror.Append(nil, fmt.Errorf("dummy error 1"), fmt.Errorf("dummy error 2")),
+			}
+			_, err := builder.Build()
+			Expect(err).To(Not(BeNil()))
+			Expect(err.Error()).To(ContainSubstring("dummy error 1"))
+			Expect(err.Error()).To(ContainSubstring("dummy error 2"))
+		})
+	})
+
+	When("WithAnnotations method is called", func() {
+		var (
+			builder *PipelineRunBuilder
+		)
+
+		BeforeEach(func() {
+			builder = NewPipelineRunBuilder("testPrefix", "testNamespace")
+		})
+
+		It("should add annotations when none previously existed", func() {
+			builder.WithAnnotations(map[string]string{
+				"annotation1": "value1",
+				"annotation2": "value2",
+			})
+			Expect(builder.pipelineRun.ObjectMeta.Annotations).To(HaveKeyWithValue("annotation1", "value1"))
+			Expect(builder.pipelineRun.ObjectMeta.Annotations).To(HaveKeyWithValue("annotation2", "value2"))
+		})
+
+		It("should update existing annotations and add new ones", func() {
+			builder.pipelineRun.ObjectMeta.Annotations = map[string]string{
+				"annotation1": "oldValue1",
+				"annotation3": "value3",
+			}
+			builder.WithAnnotations(map[string]string{
+				"annotation1": "newValue1",
+				"annotation2": "value2",
+			})
+			Expect(builder.pipelineRun.ObjectMeta.Annotations).To(HaveKeyWithValue("annotation1", "newValue1"))
+			Expect(builder.pipelineRun.ObjectMeta.Annotations).To(HaveKeyWithValue("annotation2", "value2"))
+			Expect(builder.pipelineRun.ObjectMeta.Annotations).To(HaveKeyWithValue("annotation3", "value3"))
+		})
+	})
+
+	When("WithFinalizer method is called", func() {
+		var (
+			builder *PipelineRunBuilder
+		)
+
+		BeforeEach(func() {
+			builder = NewPipelineRunBuilder("testPrefix", "testNamespace")
+		})
+
+		It("should add a finalizer when none previously existed", func() {
+			builder.WithFinalizer("finalizer1")
+			Expect(builder.pipelineRun.ObjectMeta.Finalizers).To(ContainElement("finalizer1"))
+		})
+
+		It("should append a new finalizer to the existing finalizers", func() {
+			builder.pipelineRun.ObjectMeta.Finalizers = []string{"existingFinalizer"}
+			builder.WithFinalizer("finalizer2")
+			Expect(builder.pipelineRun.ObjectMeta.Finalizers).To(ContainElements("existingFinalizer", "finalizer2"))
+		})
+	})
+
+	When("WithLabels method is called", func() {
+		var (
+			builder *PipelineRunBuilder
+		)
+
+		BeforeEach(func() {
+			builder = NewPipelineRunBuilder("testPrefix", "testNamespace")
+		})
+
+		It("should add labels when none previously existed", func() {
+			builder.WithLabels(map[string]string{
+				"label1": "value1",
+				"label2": "value2",
+			})
+			Expect(builder.pipelineRun.ObjectMeta.Labels).To(HaveKeyWithValue("label1", "value1"))
+			Expect(builder.pipelineRun.ObjectMeta.Labels).To(HaveKeyWithValue("label2", "value2"))
+		})
+
+		It("should update existing labels and add new ones", func() {
+			builder.pipelineRun.ObjectMeta.Labels = map[string]string{
+				"label1": "oldValue1",
+				"label3": "value3",
+			}
+			builder.WithLabels(map[string]string{
+				"label1": "newValue1",
+				"label2": "value2",
+			})
+			Expect(builder.pipelineRun.ObjectMeta.Labels).To(HaveKeyWithValue("label1", "newValue1"))
+			Expect(builder.pipelineRun.ObjectMeta.Labels).To(HaveKeyWithValue("label2", "value2"))
+			Expect(builder.pipelineRun.ObjectMeta.Labels).To(HaveKeyWithValue("label3", "value3"))
+		})
+	})
+
+	When("WithObjectReferences method is called", func() {
+		It("should add parameters based on the provided client.Objects", func() {
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			configMap1 := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "configName1",
+					Namespace: "configNamespace1",
+				},
+			}
+			configMap1.Kind = "ConfigMap"
+			configMap2 := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "configName2",
+					Namespace: "configNamespace2",
+				},
+			}
+			configMap2.Kind = "ConfigMap"
+
+			builder.WithObjectReferences(configMap1, configMap2)
+
+			Expect(builder.pipelineRun.Spec.Params).To(ContainElement(tektonv1.Param{
+				Name:  "configMap",
+				Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "configNamespace1/configName1"},
+			}))
+			Expect(builder.pipelineRun.Spec.Params).To(ContainElement(tektonv1.Param{
+				Name:  "configMap",
+				Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "configNamespace2/configName2"},
+			}))
+		})
+	})
+
+	When("WithObjectSpecsAsJson method is called", func() {
+		It("should add parameters with JSON representation of the object's Spec", func() {
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			pod1 := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container1",
+							Image: "image1",
+						},
+					},
+				},
+			}
+			pod1.Kind = "Pod"
+			pod2 := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container2",
+							Image: "image2",
+						},
+					},
+				},
+			}
+			pod2.Kind = "Pod"
+
+			builder.WithObjectSpecsAsJson(pod1, pod2)
+
+			Expect(builder.pipelineRun.Spec.Params).To(ContainElement(tektonv1.Param{
+				Name: "pod",
+				Value: tektonv1.ParamValue{
+					Type:      tektonv1.ParamTypeString,
+					StringVal: `{"containers":[{"name":"container1","image":"image1","resources":{}}]}`,
+				},
+			}))
+			Expect(builder.pipelineRun.Spec.Params).To(ContainElement(tektonv1.Param{
+				Name: "pod",
+				Value: tektonv1.ParamValue{
+					Type:      tektonv1.ParamTypeString,
+					StringVal: `{"containers":[{"name":"container2","image":"image2","resources":{}}]}`,
+				},
+			}))
+		})
+	})
+
+	When("WithParams method is called", func() {
+		It("should append the provided parameters to the PipelineRun's spec", func() {
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+
+			param1 := tektonv1.Param{
+				Name:  "param1",
+				Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "value1"},
+			}
+			param2 := tektonv1.Param{
+				Name:  "param2",
+				Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "value2"},
+			}
+
+			builder.WithParams(param1, param2)
+
+			Expect(builder.pipelineRun.Spec.Params).To(ContainElements(param1, param2))
+		})
+	})
+
+	When("WithOwner method is called", func() {
+		var (
+			builder   *PipelineRunBuilder
+			configMap *corev1.ConfigMap
+		)
+
+		BeforeEach(func() {
+			builder = NewPipelineRunBuilder("testPrefix", "testNamespace")
+			configMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "configName",
+					Namespace: "configNamespace",
+				},
+			}
+			configMap.Kind = "Config"
+		})
+
+		It("should handle owner without errors", func() {
+			builder.WithOwner(configMap)
+			_, err := builder.Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should have added owner annotations to the PipelineRun", func() {
+			builder.WithOwner(configMap)
+			Expect(builder.pipelineRun.Annotations).ToNot(BeEmpty())
+		})
+	})
+
+	When("WithServiceAccount method is called", func() {
+		It("should set the ServiceAccountName for the PipelineRun's TaskRunTemplate", func() {
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			serviceAccount := "sampleServiceAccount"
+			builder.WithServiceAccount(serviceAccount)
+			Expect(builder.pipelineRun.Spec.TaskRunTemplate.ServiceAccountName).To(Equal(serviceAccount))
+		})
+	})
+
+	When("WithTimeouts method is called", func() {
+		It("should set the timeouts for the PipelineRun", func() {
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			timeouts := &tektonv1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
+				Tasks:    &metav1.Duration{Duration: 1 * time.Hour},
+				Finally:  &metav1.Duration{Duration: 1 * time.Hour},
+			}
+			builder.WithTimeouts(timeouts, nil)
+			Expect(builder.pipelineRun.Spec.Timeouts).To(Equal(timeouts))
+		})
+
+		It("should use the default timeouts if the given timeouts are empty", func() {
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			defaultTimeouts := &tektonv1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
+				Tasks:    &metav1.Duration{Duration: 1 * time.Hour},
+				Finally:  &metav1.Duration{Duration: 1 * time.Hour},
+			}
+			builder.WithTimeouts(nil, defaultTimeouts)
+			Expect(builder.pipelineRun.Spec.Timeouts).To(Equal(defaultTimeouts))
+		})
+	})

--- a/pkg/tekton/utils_test.go
+++ b/pkg/tekton/utils_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tekton
+
+import (
+	"github.com/konflux-ci/release-service/metadata"
+	"github.com/konflux-ci/release-service/tekton/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Utils", Ordered, func() {
+	When("isReleasePipelineRun is called", func() {
+		It("should return false when the PipelineRun is not of type 'managed' or 'tenant", func() {
+			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").Build()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isReleasePipelineRun(pipelineRun)).To(BeFalse())
+		})
+
+		It("should return true when the PipelineRun is of type 'managed'", func() {
+			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
+				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.ManagedPipelineType}).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isReleasePipelineRun(pipelineRun)).To(BeTrue())
+		})
+
+		It("should return true when the PipelineRun is of type 'tenant'", func() {
+			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
+				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.TenantPipelineType}).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isReleasePipelineRun(pipelineRun)).To(BeTrue())
+		})
+	})
+
+	When("hasPipelineSucceeded is called", func() {
+		It("should return false when the PipelineRun has not succeeded", func() {
+			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").Build()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasPipelineSucceeded(pipelineRun)).To(BeFalse())
+		})
+
+		It("should return true when the PipelineRun is of type 'managed'", func() {
+			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").Build()
+			Expect(err).NotTo(HaveOccurred())
+			pipelineRun.Status.MarkSucceeded("", "")
+			Expect(hasPipelineSucceeded(pipelineRun)).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
This is coming from the konflux-ci/release-service repo. Originally this is part of a shared set of utils.
These methods should be useful in the future to build the PipelineRun definition.

ref: CWFHEALTH-3293