### PR TITLE
Add required rpms-signature-scan task

### DIFF
--- a/.tekton/mintmaker-pull-request.yaml
+++ b/.tekton/mintmaker-pull-request.yaml
@@ -372,6 +372,29 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+    - name: rpms-signature-scan
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values: ["false"]
+      runAfter:
+        - build-container
+      taskRef:
+        resolver: bundles
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.1@sha256:8e3515fdc0bbc0bcac994482a2396a8cd23e6a6fa9efaf3ec715ee312a376777
+        - name: kind
+          value: task
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: fail-unsigned
+        value: false
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/mintmaker-push.yaml
+++ b/.tekton/mintmaker-push.yaml
@@ -369,6 +369,29 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+    - name: rpms-signature-scan
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values: ["false"]
+      runAfter:
+        - build-container
+      taskRef:
+        resolver: bundles
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.1@sha256:8e3515fdc0bbc0bcac994482a2396a8cd23e6a6fa9efaf3ec715ee312a376777
+        - name: kind
+          value: task
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: fail-unsigned
+        value: false
     workspaces:
     - name: workspace
     - name: git-auth


### PR DESCRIPTION
Starting from Nov 1st, EC began enforcing the required `rpms-signature-scan` task.