### PR TITLE
Enable Go managers

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -313,11 +313,17 @@
   },
   "gomod": {
     "additionalBranchPrefix": "{{baseBranch}}/",
-    "branchPrefix": "konflux/mintmaker/"
+    "branchPrefix": "konflux/mintmaker/",
+    "schedule": [
+      "after 5am on sunday"
+    ]
   },
   "ocb": {
     "additionalBranchPrefix": "{{baseBranch}}/",
-    "branchPrefix": "konflux/mintmaker/"
+    "branchPrefix": "konflux/mintmaker/",
+    "schedule": [
+      "after 5am on sunday"
+    ]
   },
   "forkProcessing": "enabled",
   "allowedPostUpgradeCommands": [

--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -321,8 +321,6 @@
     ]
   },
   "gomod": {
-    "additionalBranchPrefix": "{{baseBranch}}/",
-    "branchPrefix": "konflux/mintmaker/",
     "schedule": [
       "after 5am on sunday"
     ],
@@ -332,8 +330,6 @@
     ]
   },
   "ocb": {
-    "additionalBranchPrefix": "{{baseBranch}}/",
-    "branchPrefix": "konflux/mintmaker/",
     "schedule": [
       "after 5am on sunday"
     ]

--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -97,6 +97,15 @@
         "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
         "recreateWhen": "always",
         "rebaseWhen": "behind-base-branch"
+      },
+      {
+        "matchManagers": [
+          "gomod"
+        ],
+        "matchDepTypes": [
+          "indirect"
+        ],
+        "enabled": true
       }
     ],
     "schedule": [
@@ -316,6 +325,10 @@
     "branchPrefix": "konflux/mintmaker/",
     "schedule": [
       "after 5am on sunday"
+    ],
+    "postUpdateOptions": [
+      "gomodUpdateImportPaths",
+      "gomodTidy"
     ]
   },
   "ocb": {

--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -57,7 +57,9 @@
     "poetry",
     "pyenv",
     "runtime-version",
-    "setup-cfg"
+    "setup-cfg",
+    "gomod",
+    "ocb"
   ],
   "tekton": {
     "additionalBranchPrefix": "",
@@ -308,6 +310,14 @@
     "schedule": [
       "after 5am on saturday"
     ]
+  },
+  "gomod": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "ocb": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
   },
   "forkProcessing": "enabled",
   "allowedPostUpgradeCommands": [


### PR DESCRIPTION
2 Go managers are added in this commit. I also moved the `branchPrefix` attribute one level higher as it seems from the documentation the effect stays the same.

Closes [CWFHEALTH-3173](https://issues.redhat.com/browse/CWFHEALTH-3173)
Related PR: https://github.com/konflux-ci/mintmaker-renovate-image/pull/71