### PR TITLE
Migrate matchPackagePatterns to matchPackageNames

### DIFF
--- a/config/renovate/presets/force-stable-fedora.json5
+++ b/config/renovate/presets/force-stable-fedora.json5
@@ -20,8 +20,8 @@
     "packageRules": [
         {
             "description": "Don't suggest bumping to unstable fedora release",
-            "matchPackagePatterns": [
-                "[\\w.-\\/]+\\/fedora[\\w-]*"
+            "matchPackageNames": [
+                "/[\\w.-\\/]+\\/fedora[\\w-]*/"
             ],
             "matchManagers": [
                 "dockerfile",

--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -67,9 +67,9 @@
     ],
     "packageRules": [
       {
-        "matchPackagePatterns": [
-          "^quay.io/redhat-appstudio-tekton-catalog/",
-          "^quay.io/konflux-ci/tekton-catalog/"
+        "matchPackageNames": [
+          "/^quay.io/redhat-appstudio-tekton-catalog//",
+          "/^quay.io/konflux-ci/tekton-catalog//"
         ],
         "enabled": true,
         "groupName": "Konflux references",


### PR DESCRIPTION
Found during testing that Renovate suggests this change. `matchPackagePatterns` is no longer used.