### PR TITLE
Set $HOME to /home/renovate

### DIFF
--- a/pkg/renovate/job.go
+++ b/pkg/renovate/job.go
@@ -242,6 +242,12 @@ func (j *JobCoordinator) Execute(ctx context.Context, tasks []*Task) error {
 						{
 							Name:  "renovate",
 							Image: j.renovateImageUrl,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "HOME",
+									Value: "/home/renovate",
+								},
+							},
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									Prefix: "TOKEN_",


### PR DESCRIPTION
Part 1/2 of making `rpm-lockfile-prototype` work with `~/.cache`.