### PR TITLE
Update tekton manager schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,9 +3,6 @@
     "enabled": true,
     "automergeType": "pr",
     "automerge": true,
-    "platformAutomerge": true,
-    "automergeSchedule": [
-      "after 12am and before 12pm on sunday"
-    ]
+    "platformAutomerge": true
   }
 }


### PR DESCRIPTION
Renovate from MintMaker updated its global schedules. The Tekton manager only runs on Saturdays, so there's no need to specify a custom schedule. Defining a schedule outside the global schedule window could also prevent pull requests from being merged.