### PR TITLE
Disable nix manager

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -38,7 +38,6 @@
     "git-submodules",
     "hermit",
     "homebrew",
-    "nix",
     "osgi",
     "pre-commit",
     "vendir",
@@ -245,14 +244,6 @@
     ]
   },
   "homebrew": {
-    "additionalBranchPrefix": "{{baseBranch}}/",
-    "branchPrefix": "konflux/mintmaker/",
-    "schedule": [
-      "after 5am on thursday"
-    ]
-  },
-  "nix": {
-    "enabled": true,
     "additionalBranchPrefix": "{{baseBranch}}/",
     "branchPrefix": "konflux/mintmaker/",
     "schedule": [


### PR DESCRIPTION
There's a very low chance this will ever be used in Red Hat and configuring mintmaker-renovate-image to support it is tedious and brings in extra dependencies.