### PR TITLE
Fix git URL parsing

### DIFF
--- a/pkg/git/gitprovider/common.go
+++ b/pkg/git/gitprovider/common.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package gitprovider
 
-import "os"
+import (
+	"net/url"
+	"os"
+	"strings"
+)
 
 const (
 	PipelinesAsCodeWebhhokInsecureSslEnvVar = "PAC_WEBHOOK_INSECURE_SSL"
@@ -32,4 +36,20 @@ func IsInsecureSSL() bool {
 		}
 	}
 	return false
+}
+
+func ParseGitURL(gitUrl string) (*url.URL, error) {
+	gitUrl = strings.TrimSuffix(strings.TrimSuffix(gitUrl, ".git"), "/")
+
+	if strings.HasPrefix(gitUrl, "git@") {
+		gitUrl = strings.Replace(gitUrl, ":", "/", 1)
+		gitUrl = strings.Replace(gitUrl, "git@", "https://", 1)
+	}
+
+	parsedUrl, err := url.Parse(gitUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsedUrl, nil
 }

--- a/pkg/git/gitprovider/common_test.go
+++ b/pkg/git/gitprovider/common_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitprovider
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestParseGitURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		gitUrl  string
+		want    *url.URL
+		wantErr bool
+	}{
+		{
+			name:   "HTTPS URL",
+			gitUrl: "https://github.com/user/repo.git",
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+				Path:   "/user/repo",
+			},
+			wantErr: false,
+		},
+		{
+			name:   "SSH URL",
+			gitUrl: "git@github.com:user/repo.git",
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+				Path:   "/user/repo",
+			},
+			wantErr: false,
+		},
+		{
+			name:   "URL without .git suffix",
+			gitUrl: "https://gitlab.company.com/user/repo",
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "gitlab.company.com",
+				Path:   "/user/repo",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Invalid URL",
+			gitUrl:  "ht@tp://fake-url",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseGitURL(tt.gitUrl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseGitURL() error = %v, expected %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got.String() != tt.want.String() {
+				t.Errorf("ParseGitURL() result = %v, expected %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/git/scmcomponent.go
+++ b/pkg/git/scmcomponent.go
@@ -3,6 +3,8 @@ package git
 import (
 	"net/url"
 	"strings"
+
+	gp "github.com/konflux-ci/mintmaker/pkg/git/gitprovider"
 )
 
 const InternalDefaultBranch = "$DEFAULTBRANCH"
@@ -16,7 +18,7 @@ type ScmComponent struct {
 }
 
 func NewScmComponent(platform string, repositoryUrl string, revision string, componentName string, namespaceName string) (*ScmComponent, error) {
-	url, err := url.Parse(strings.TrimSuffix(strings.TrimSuffix(repositoryUrl, ".git"), "/"))
+	url, err := gp.ParseGitURL(repositoryUrl)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes a bug where the controller crashed if git url was provided in format `git@...` by replacing the 2 occurences of `url.Parse()` with more sophisticated function. The error causing controller to crash is happening inside `NewScmComponent()`. The code inside `getGitProvider()` did not produce an error, however it always jumped into the second block, relying on component annotations.

Closes [CWFHEALTH-3811](https://issues.redhat.com/browse/CWFHEALTH-3811).