### PR TITLE
Implement new PipelineRuns controller

### DIFF
--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -22,7 +22,9 @@ import (
 
 	. "github.com/konflux-ci/mintmaker/pkg/common"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -30,21 +32,87 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+var (
+	MaxSimultaneousPipelineRuns = 5
+	MintMakerAppstudioLabel     = "mintmaker.appstudio.redhat.com/platform"
+)
+
+// Collect pipelineruns with state 'running' or 'started'
+func countRunningPipelineRuns(existingPipelineRuns tektonv1.PipelineRunList) (int, error) {
+	var runningPipelineRuns []*tektonv1.PipelineRun
+	for i, pipelineRun := range existingPipelineRuns.Items {
+		if len(pipelineRun.Status.Conditions) > 0 &&
+			pipelineRun.Status.Conditions[0].Status == corev1.ConditionUnknown &&
+			(pipelineRun.Status.Conditions[0].Reason == tektonv1.PipelineRunReasonRunning.String() ||
+				pipelineRun.Status.Conditions[0].Reason == tektonv1.PipelineRunReasonStarted.String()) {
+			runningPipelineRuns = append(runningPipelineRuns, &existingPipelineRuns.Items[i])
+		}
+	}
+	numRunning := len(runningPipelineRuns)
+
+	return numRunning, nil
+}
+
 // PipelineRunReconciler reconciles a PipelineRun object
 type PipelineRunReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the PipelineRun object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/reconcile
+func (r *PipelineRunReconciler) listExistingPipelineRuns(ctx context.Context, req ctrl.Request) (tektonv1.PipelineRunList, error) {
+
+	log := ctrllog.FromContext(ctx).WithName("PipelineRun")
+	var existingPipelineRuns tektonv1.PipelineRunList
+
+	err := r.Client.List(ctx, &existingPipelineRuns, client.InNamespace(req.Namespace))
+	if err != nil {
+		log.Error(err, "Unable to list existing pipelineruns")
+		return tektonv1.PipelineRunList{}, err
+	}
+	return existingPipelineRuns, nil
+}
+
+func filterPipelineRunListWithLabel(pipelineRunList tektonv1.PipelineRunList, label string) tektonv1.PipelineRunList {
+	pipelineRuns := []tektonv1.PipelineRun{}
+
+	for _, pipelineRun := range pipelineRunList.Items {
+		if pipelineRun.Labels[MintMakerAppstudioLabel] == label {
+			pipelineRuns = append(pipelineRuns, pipelineRun)
+		}
+	}
+	return tektonv1.PipelineRunList{Items: pipelineRuns}
+}
+
+func (r *PipelineRunReconciler) launchUpToNPipelineRuns(numToLaunch int, existingPipelineRuns tektonv1.PipelineRunList, ctx context.Context) error {
+
+	log := ctrllog.FromContext(ctx).WithName("PipelineRun")
+	ctx = ctrllog.IntoContext(ctx, log)
+
+	if numToLaunch <= 0 {
+		return nil
+	}
+	numLaunched := 0
+	for _, pipelineRun := range existingPipelineRuns.Items {
+		if pipelineRun.IsPending() {
+			original := pipelineRun.DeepCopy()
+			pipelineRun.Spec.Status = ""
+			patch := client.MergeFrom(original)
+			err := r.Client.Patch(ctx, &pipelineRun, patch)
+			if err != nil {
+				log.Error(err, "Unable to update pipelinerun status")
+				return err
+			}
+			log.Info(fmt.Sprintf("PipelineRun is updated (pending state removed): %s", pipelineRun.Name))
+			numLaunched += 1
+			if numLaunched == numToLaunch {
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
 func (r *PipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx).WithName("PipelineRun")
 	ctx = ctrllog.IntoContext(ctx, log)
@@ -53,7 +121,37 @@ func (r *PipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	log.Info(fmt.Sprintf("PipelineRun is updated: %v", req.NamespacedName))
+	// Get pipelineruns
+	existingPipelineRuns, err := r.listExistingPipelineRuns(ctx, req)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	numRunning, err := countRunningPipelineRuns(existingPipelineRuns)
+	if err != nil {
+		log.Error(err, "Unable to count running pipelineruns")
+		return ctrl.Result{}, err
+	}
+
+	githubPipelineRuns := filterPipelineRunListWithLabel(existingPipelineRuns, "github")
+
+	// Launch up to N pipelineruns, 'github' ones first
+	numToLaunch := MaxSimultaneousPipelineRuns - numRunning
+	err = r.launchUpToNPipelineRuns(numToLaunch, githubPipelineRuns, ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	numRunning, err = countRunningPipelineRuns(existingPipelineRuns)
+	if err != nil {
+		log.Error(err, "Unable to count running pipelineruns")
+		return ctrl.Result{}, err
+	}
+	numToLaunch = MaxSimultaneousPipelineRuns - numRunning
+	err = r.launchUpToNPipelineRuns(numToLaunch, existingPipelineRuns, ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	return ctrl.Result{}, nil
 }
@@ -62,14 +160,22 @@ func (r *PipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *PipelineRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&tektonv1.PipelineRun{}).
-		/* TODO: For the time being we just ignore all types of events
-		In a second implementation we are going to listen to changes in the pipelinerun
-		and one of these events will have to return true, and the reconcile can be stuff
-		based on the event */
 		WithEventFilter(predicate.Funcs{
-			CreateFunc:  func(createEvent event.CreateEvent) bool { return false },
-			DeleteFunc:  func(deleteEvent event.DeleteEvent) bool { return false },
-			UpdateFunc:  func(updateEvent event.UpdateEvent) bool { return true },
+			CreateFunc: func(createEvent event.CreateEvent) bool {
+				if pipelineRun, ok := createEvent.Object.(*tektonv1.PipelineRun); ok {
+					return pipelineRun.Spec.Status == tektonv1.PipelineRunSpecStatusPending
+				}
+				return false
+			},
+			DeleteFunc: func(deleteEvent event.DeleteEvent) bool { return false },
+			UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+				if oldPipelineRun, ok := updateEvent.ObjectOld.(*tektonv1.PipelineRun); ok {
+					if newPipelineRun, ok := updateEvent.ObjectNew.(*tektonv1.PipelineRun); ok {
+						return oldPipelineRun.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() && !newPipelineRun.Status.GetCondition(apis.ConditionSucceeded).IsUnknown()
+					}
+				}
+				return false
+			},
 			GenericFunc: func(genericEvent event.GenericEvent) bool { return false },
 		}).
 		Complete(r)

--- a/internal/controller/pipelinerun_controller_test.go
+++ b/internal/controller/pipelinerun_controller_test.go
@@ -14,19 +14,118 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// What to test:
+// - check countRunningPipelineRuns
+// - with a queue of 3 pipelineruns, when one finishes one other starts and one stays pending
+
 package controller
 
 import (
+	"strconv"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+
+	local_tekton "github.com/konflux-ci/mintmaker/internal/pkg/tekton"
+	. "github.com/konflux-ci/mintmaker/pkg/common"
 )
 
-var _ = Describe("PipelineRun Controller", func() {
-	Context("When reconciling a resource", func() {
+var _ = Describe("PipelineRun Controller", FlakeAttempts(3), func() {
+	Context("When reconciling pipelineruns", func() {
 
-		It("should successfully reconcile the resource", func() {
+		originalMaxSimultaneousPipelineRuns := MaxSimultaneousPipelineRuns
 
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		_ = BeforeEach(func() {
+			createNamespace(MintMakerNamespaceName)
+			MaxSimultaneousPipelineRuns = 2
+
+			for i := range 3 {
+				pplrName := "pplnr" + strconv.Itoa(i)
+				pipelineRunBuilder := local_tekton.NewPipelineRunBuilder(pplrName, MintMakerNamespaceName)
+				pipelinerun, err := pipelineRunBuilder.Build()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Create(ctx, pipelinerun)).Should(Succeed())
+			}
+			Eventually(listPipelineRuns).WithArguments(MintMakerNamespaceName).Should(HaveLen(3))
+		})
+
+		_ = AfterEach(func() {
+			MaxSimultaneousPipelineRuns = originalMaxSimultaneousPipelineRuns
+
+			// Delete pipelineruns, so they don't leak to other tests
+			pipelineRuns := listPipelineRuns(MintMakerNamespaceName)
+			for _, pipelinerun := range pipelineRuns {
+				Expect(k8sClient.Delete(ctx, &pipelinerun)).Should(Succeed())
+			}
+		})
+
+		It("should successfully launch new pipelineruns", func() {
+
+			existingPipelineRuns := tektonv1.PipelineRunList{
+				Items: listPipelineRuns(MintMakerNamespaceName),
+			}
+			count := 0
+			for _, pipelineRun := range existingPipelineRuns.Items {
+				if pipelineRun.Spec.Status == "" {
+					count += 1
+				}
+			}
+			Expect(count).Should(Equal(MaxSimultaneousPipelineRuns))
+		})
+	})
+
+	Context("When launching new pipelineruns", func() {
+
+		originalMaxSimultaneousPipelineRuns := MaxSimultaneousPipelineRuns
+
+		_ = BeforeEach(func() {
+			createNamespace(MintMakerNamespaceName)
+			MaxSimultaneousPipelineRuns = 1
+
+			pplrName := "pplnr1"
+			labels := make(map[string]string)
+			labels[MintMakerAppstudioLabel] = "github"
+			pipelineRunBuilder := local_tekton.NewPipelineRunBuilder(pplrName, MintMakerNamespaceName)
+			pipelinerun, err := pipelineRunBuilder.WithLabels(labels).Build()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, pipelinerun)).Should(Succeed())
+
+			pplrName = "pplnr2"
+			pipelineRunBuilder = local_tekton.NewPipelineRunBuilder(pplrName, MintMakerNamespaceName)
+			pipelinerun, err = pipelineRunBuilder.Build()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(ctx, pipelinerun)).Should(Succeed())
+
+			Eventually(listPipelineRuns).WithArguments(MintMakerNamespaceName).Should(HaveLen(2))
+		})
+
+		_ = AfterEach(func() {
+			MaxSimultaneousPipelineRuns = originalMaxSimultaneousPipelineRuns
+
+			// Delete pipelineruns, so they don't leak to other tests
+			pipelineRuns := listPipelineRuns(MintMakerNamespaceName)
+			for _, pipelinerun := range pipelineRuns {
+				Expect(k8sClient.Delete(ctx, &pipelinerun)).Should(Succeed())
+			}
+		})
+		// FIXME improve this test
+		// see discussion in https://github.com/konflux-ci/mintmaker/pull/132
+		It("should launch 'github' pipelines first", func() {
+
+			var flag1, flag2 bool = false, false
+
+			pipelineRuns := listPipelineRuns(MintMakerNamespaceName)
+			for _, plr := range pipelineRuns {
+				if plr.Labels[MintMakerAppstudioLabel] == "github" {
+					Expect(plr.Spec.Status).To(BeEmpty())
+					flag1 = true
+				} else {
+					Expect(string(plr.Spec.Status)).To(Equal(tektonv1.PipelineRunSpecStatusPending))
+					flag2 = true
+				}
+			}
+			Expect(flag1 && flag2).To(BeTrue()) //make sure both clauses were executed
 		})
 	})
 })

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -101,6 +101,9 @@ var _ = BeforeSuite(func() {
 	err = (NewDependencyUpdateCheckReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorderFor("DependencyUpdateCheckController"))).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&PipelineRunReconciler{Client: k8sManager.GetClient(), Scheme: k8sManager.GetScheme()}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)


### PR DESCRIPTION
This commit implements a new controller/reconciler for PipelineRuns. Its main responsibility is to launch new pipelineruns when another one finishes, and try to keep up to a maximum number of pipelineruns active at any given time.

Besides that, it also launches github pipelineruns first, as a temporary means of decreasing the chance that their temporary token will expire.


### Testing remarks
The new controller worked fine in my manual tests. I created several pipelineruns, and watched how they were progressively launched.

The unit tests are having an intermittent behavior. About half of the times I ran them, they fail during the `BeforeEach` phases, seemingly because they fail to create the pipelineruns (or maybe to retrieve them with `listPipelineRuns`). I guess we will need to debug this function to solve this, so maybe we can leave it to another task in the epic.