### PR TITLE
Manage registry access credentials in PipelineRuns

### DIFF
--- a/internal/pkg/component/component.go
+++ b/internal/pkg/component/component.go
@@ -8,6 +8,7 @@ import (
 	github "github.com/konflux-ci/mintmaker/internal/pkg/component/github"
 	gitlab "github.com/konflux-ci/mintmaker/internal/pkg/component/gitlab"
 	utils "github.com/konflux-ci/mintmaker/internal/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,7 +24,7 @@ type GitComponent interface {
 	GetToken() (string, error)
 	GetBranch() (string, error)
 	GetAPIEndpoint() string
-	GetRenovateConfig() (string, error)
+	GetRenovateConfig(*corev1.Secret) (string, error)
 }
 
 func NewGitComponent(comp *appstudiov1alpha1.Component, timestamp int64, client client.Client, ctx context.Context) (GitComponent, error) {

--- a/internal/pkg/component/github/github.go
+++ b/internal/pkg/component/github/github.go
@@ -281,8 +281,8 @@ func (c *Component) getAppSlug() (string, error) {
 	return slug, nil
 }
 
-func (c *Component) GetRenovateConfig() (string, error) {
-	baseConfig, err := c.GetRenovateBaseConfig(c.client, c.ctx)
+func (c *Component) GetRenovateConfig(registrySecret *corev1.Secret) (string, error) {
+	baseConfig, err := c.GetRenovateBaseConfig(c.client, c.ctx, registrySecret)
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/component/gitlab/gitlab.go
+++ b/internal/pkg/component/gitlab/gitlab.go
@@ -173,8 +173,8 @@ func (c *Component) getDefaultBranch() (string, error) {
 	return "main", nil
 }
 
-func (c *Component) GetRenovateConfig() (string, error) {
-	baseConfig, err := c.GetRenovateBaseConfig(c.client, c.ctx)
+func (c *Component) GetRenovateConfig(registrySecret *corev1.Secret) (string, error) {
+	baseConfig, err := c.GetRenovateBaseConfig(c.client, c.ctx, registrySecret)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Secure registries require credentials for image pulling, currently we create the secret in mintmaker namespace and use that for all components, we'll follow the same approach in this refactoring, but modify it to mount the secret in PipelineRuns.