### PR TITLE
Configure pipeline-migration-tool run for tekton manager

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -116,7 +116,13 @@
     ],
     "schedule": [
       "after 5am on saturday"
-    ]
+    ],
+    "postUpgradeTasks": {
+      "commands": [
+        "pipeline-migration-tool -u '[{{#each upgrades}}{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"currentDigest\": \"{{{currentDigest}}}\", \"newValue\": \"{{{newValue}}}\", \"newDigest\": \"{{{newDigest}}}\", \"packageFile\": \"{{{packageFile}}}\", \"parentDir\": \"{{{parentDir}}}\", \"depTypes\": [{{#each depTypes}}\"{{{this}}}\"{{#unless @last}},{{\/unless}}{{\/each}}]}{{#unless @last}},{{\/unless}}{{\/each}}]'"
+      ],
+      "executionMode": "branch"
+    }
   },
   "dockerfile": {
     "enabled": true,
@@ -352,7 +358,8 @@
   },
   "forkProcessing": "enabled",
   "allowedCommands": [
-    "^rpm-lockfile-prototype rpms.in.yaml$"
+    "^rpm-lockfile-prototype rpms.in.yaml$",
+    "^pipeline-migration-tool -u '\\[{{#each upgrades}}{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"currentDigest\": \"{{{currentDigest}}}\", \"newValue\": \"{{{newValue}}}\", \"newDigest\": \"{{{newDigest}}}\", \"packageFile\": \"{{{packageFile}}}\", \"parentDir\": \"{{{parentDir}}}\", \"depTypes\": \\[{{#each depTypes}}\"{{{this}}}\"{{#unless @last}},{{\/unless}}{{\/each}}\\]}{{#unless @last}},{{\/unless}}{{\/each}}\\]'$"
   ],
   "updateNotScheduled": false,
   "dependencyDashboard": false,


### PR DESCRIPTION
STONEBLD-2824

Executable script pipeline-migration-tool is available from the Mintmaker image.

This change works with https://github.com/konflux-ci/mintmaker-renovate-image/pull/85 together.