### PR TITLE
Update Renovate command and set ownership

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -282,14 +282,43 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(comp component.GitCo
 		return nil, err
 	}
 
-	if err := controllerutil.SetOwnerReference(pipelineRun, registry_secret, r.Scheme); err != nil {
+	// Set ownership so all resources get deleted once the job is deleted
+	// ownership for renovateSecret
+	if err := controllerutil.SetOwnerReference(pipelineRun, renovateSecret, r.Scheme); err != nil {
 		return nil, err
 	}
-	if err := r.Client.Update(ctx, registry_secret); err != nil {
+	if err := r.Client.Update(ctx, renovateSecret); err != nil {
 		return nil, err
 	}
 
-	// TODO: set ownerReferences for renovateConfigMap and renovateSecret
+	// ownership for registry_secret
+	if registry_secret != nil {
+		if err := controllerutil.SetOwnerReference(pipelineRun, registry_secret, r.Scheme); err != nil {
+			return nil, err
+		}
+		if err := r.Client.Update(ctx, registry_secret); err != nil {
+			return nil, err
+		}
+	}
+
+	// ownership for the renovateConfigMap
+	if err := controllerutil.SetOwnerReference(pipelineRun, renovateConfigMap, r.Scheme); err != nil {
+		return nil, err
+	}
+	if err := r.Client.Update(ctx, renovateConfigMap); err != nil {
+		return nil, err
+	}
+
+	// ownership for the caConfigMap
+	if caConfigMap != nil {
+		if err := controllerutil.SetOwnerReference(pipelineRun, caConfigMap, r.Scheme); err != nil {
+			return nil, err
+		}
+		if err := r.Client.Update(ctx, caConfigMap); err != nil {
+			return nil, err
+		}
+	}
+
 	return pipelineRun, nil
 }
 

--- a/internal/pkg/tekton/pipeline_run_builder.go
+++ b/internal/pkg/tekton/pipeline_run_builder.go
@@ -106,10 +106,9 @@ func NewPipelineRunBuilder(name, namespace string) *PipelineRunBuilder {
 								TaskSpec: tektonv1.TaskSpec{
 									Steps: []tektonv1.Step{
 										{
-											Name: "renovate",
-											// TODO: use default, or get from ENV
+											Name:   "renovate",
 											Image:  "quay.io/konflux-ci/mintmaker-renovate-image:latest",
-											Script: `echo "Running Renovate"; sleep 10`,
+											Script: `RENOVATE_TOKEN=$(cat /etc/renovate/secret/renovate-token) RENOVATE_CONFIG_FILE=/etc/renovate/config/renovate.json renovate`,
 										},
 									},
 								},


### PR DESCRIPTION
Changing the placeholder command to the actual renovate command. Additionally with this commit we are setting all the necessary ownership to all the resources (ConfigMaps and secrets). So that we can be sure that one a PipelineRun is removed from the cluster all its corresponding resources are removed with it.