### PR TITLE
Implement github installation token management

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -19,12 +19,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strconv"
 	"time"
 
 	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	mmv1alpha1 "github.com/konflux-ci/mintmaker/api/v1alpha1"
-	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
 	"github.com/konflux-ci/mintmaker/internal/pkg/component"
+	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
 	"github.com/konflux-ci/mintmaker/internal/pkg/tekton"
 	"github.com/konflux-ci/mintmaker/internal/pkg/utils"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -227,10 +228,12 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(comp component.GitCo
 	// Creating the pipelineRun definition
 	builder := tekton.NewPipelineRunBuilder(name, MintMakerNamespaceName).
 		WithLabels(map[string]string{
-			"mintmaker.appstudio.redhat.com/application":  comp.GetApplication(),
-			"mintmaker.appstudio.redhat.com/component":    comp.GetName(),
-			"mintmaker.appstudio.redhat.com/git-platform": comp.GetPlatform(), // (github, gitlab)
-			"mintmaker.appstudio.redhat.com/git-host":     comp.GetHost(),     // github.com, gitlab.com, gitlab.other.com
+			"mintmaker.appstudio.redhat.com/application":         comp.GetApplication(),
+			"mintmaker.appstudio.redhat.com/component":           comp.GetName(),
+			"mintmaker.appstudio.redhat.com/namespace":           comp.GetNamespace(),
+			"mintmaker.appstudio.redhat.com/git-platform":        comp.GetPlatform(), // (github, gitlab)
+			"mintmaker.appstudio.redhat.com/git-host":            comp.GetHost(),     // github.com, gitlab.com, gitlab.other.com
+			"mintmaker.appstudio.redhat.com/reconcile-timestamp": strconv.FormatInt(comp.GetTimestamp(), 10),
 		})
 	builder.WithServiceAccount("mintmaker-controller-manager")
 

--- a/internal/controller/pipelinerun_controller_test.go
+++ b/internal/controller/pipelinerun_controller_test.go
@@ -83,7 +83,7 @@ var _ = Describe("PipelineRun Controller", FlakeAttempts(3), func() {
 
 			pplrName := "pplnr1"
 			labels := make(map[string]string)
-			labels[MintMakerAppstudioLabel] = "github"
+			labels[MintMakerGitPlatformLabel] = "github"
 			pipelineRunBuilder := tekton.NewPipelineRunBuilder(pplrName, MintMakerNamespaceName)
 			pipelinerun, err := pipelineRunBuilder.WithLabels(labels).Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -115,7 +115,7 @@ var _ = Describe("PipelineRun Controller", FlakeAttempts(3), func() {
 
 			pipelineRuns := listPipelineRuns(MintMakerNamespaceName)
 			for _, plr := range pipelineRuns {
-				if plr.Labels[MintMakerAppstudioLabel] == "github" {
+				if plr.Labels[MintMakerGitPlatformLabel] == "github" {
 					Expect(plr.Spec.Status).To(BeEmpty())
 					flag1 = true
 				} else {

--- a/internal/pkg/component/github/cache.go
+++ b/internal/pkg/component/github/cache.go
@@ -16,6 +16,9 @@ package github
 
 import (
 	"sync"
+	"time"
+
+	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
 )
 
 type Cache struct {
@@ -32,4 +35,38 @@ func (c *Cache) Get(key string) (interface{}, bool) {
 
 func (c *Cache) Set(key string, value interface{}) {
 	c.data.Store(key, value)
+}
+
+type TokenInfo struct {
+	Token     string
+	ExpiresAt time.Time
+}
+
+type TokenCache struct {
+	mu      sync.RWMutex
+	entries map[string]TokenInfo
+}
+
+func (c *TokenCache) Set(key string, tokenInfo TokenInfo) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[key] = tokenInfo
+}
+
+func (c *TokenCache) Get(key string) (TokenInfo, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, exists := c.entries[key]
+	if !exists {
+		return TokenInfo{}, false
+	}
+
+	// when token is close to expiring, we can't use it
+	if time.Until(entry.ExpiresAt) < GhTokenRenewThreshold {
+		return TokenInfo{}, false
+	}
+
+	return entry, true
 }

--- a/internal/pkg/component/github/github_test.go
+++ b/internal/pkg/component/github/github_test.go
@@ -1,0 +1,34 @@
+package github
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Github Suite")
+}
+
+var _ = Describe("Module-level token cache variable", func() {
+
+	Context("After the module initializes", func() {
+
+		It("Should be possible to assign values to token cache with Set method", func() {
+
+			testKey := "test_key"
+			tokenInfo := TokenInfo{
+				Token: "token_string", ExpiresAt: time.Now().Add(time.Hour),
+			}
+
+			ghAppInstallationTokenCache.Set(testKey, tokenInfo)
+
+			result, _ := ghAppInstallationTokenCache.Get(testKey)
+			Expect(result).Should(Equal(tokenInfo))
+		})
+	})
+})

--- a/internal/pkg/constant/constants.go
+++ b/internal/pkg/constant/constants.go
@@ -14,6 +14,8 @@
 
 package constant
 
+import "time"
+
 const (
 	// The namespace name where mintmaker is running
 	MintMakerNamespaceName = "mintmaker"
@@ -24,4 +26,8 @@ const (
 
 	RenovateImageEnvName    = "RENOVATE_IMAGE"
 	DefaultRenovateImageURL = "quay.io/konflux-ci/mintmaker-renovate-image:latest"
+
+	GhTokenValidity       = 1 * time.Hour
+	GhTokenUsageWindow    = 30 * time.Minute
+	GhTokenRenewThreshold = GhTokenValidity - GhTokenUsageWindow
 )


### PR DESCRIPTION
Implement github installation token management

This commit implements the logic to mange github installation tokens.

These tokens have a lifetime of one hour, and are limited in number. The logic to renew them responsibly is now implemented in the github module.

Other changes implemented are:
- new reconcile-timestamp label in github components
- extraction of tekton label keys in the pipelinerun controller module
- token cache in github module, to store tokens and their expiration time
- logic to cancel pipelineruns, in case there is a problem in any of launching steps

### Testing remarks
I have ran tests locally with minikube, and also in the dev cluster, and things seem to be working as expected.
- I made timing tests with many pipelineruns locally, to check if the token renewal was happening only at the times it was expected
- I made e2e tests in the dev cluster, to check if the token update in the secret is working as expected
- I made e2e tests to check if the pipelinerun cancelling logic is working fine