### PR TITLE
Enable pip-compile as allowedPostUpgradeCommand

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -310,7 +310,8 @@
   },
   "forkProcessing": "enabled",
   "allowedPostUpgradeCommands": [
-    "^rpm-lockfile-prototype rpms.in.yaml$"
+    "^rpm-lockfile-prototype rpms.in.yaml$",
+    "^pipx run --python python3\\.1\\d --spec pip-tools pip-compile[\\sa-zA-Z\\-=\\.\/]+$"
   ],
   "updateNotScheduled": false,
   "dependencyDashboard": false


### PR DESCRIPTION
We have a use case where we want to trigger a pip-compile requirements.txt file refresh as a post upgrafe command. The regex is flexible to match and arbitraty number of flags while calling pip-compile