### PR TITLE
Do not update PRs with konflux-nudge label

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -313,5 +313,6 @@
     "^rpm-lockfile-prototype rpms.in.yaml$"
   ],
   "updateNotScheduled": false,
-  "dependencyDashboard": false
+  "dependencyDashboard": false,
+  "stopUpdatingLabel": "konflux-nudge"
 }


### PR DESCRIPTION
CWFHEALTH-3882

When Renovate finds such PRs, this is logged:
```
 INFO: Branch updating is skipped because stopUpdatingLabel is present in config
```