### PR TITLE
Break, instead of continue...

### DIFF
--- a/internal/pkg/component/github/github.go
+++ b/internal/pkg/component/github/github.go
@@ -234,7 +234,7 @@ func (c *Component) getAppInstallations() ([]AppInstallation, error) {
 					// If App is installed with insufficient permission, this ListRepos call
 					// will return error, we should just skip checking this installation
 					// TODO: error logging
-					continue
+					break
 				}
 				for _, repo := range repos.Repositories {
 					appInstall.Repositories = append(appInstall.Repositories, repo.GetFullName())


### PR DESCRIPTION
...in case of problematic GitHub App installations. We shouldn't continue, but we should `break`.