### PR TITLE
Shorten name due to char limits on some objects

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -175,7 +175,7 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(comp component.GitCo
 
 	log := ctrllog.FromContext(ctx).WithName("DependencyUpdateCheckController")
 	ctx = ctrllog.IntoContext(ctx, log)
-	name := fmt.Sprintf("renovate-%d-%s-%s", comp.GetTimestamp(), RandomString(8), comp.GetName())
+	name := fmt.Sprintf("renovate-%d-%s", comp.GetTimestamp(), RandomString(8))
 	registry_secret, err := r.createMergedPullSecret(ctx)
 
 	renovateConfig, err := comp.GetRenovateConfig(registry_secret)

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	MaxSimultaneousPipelineRuns = 5
+	MaxSimultaneousPipelineRuns = 20
 	MintMakerAppstudioLabel     = "mintmaker.appstudio.redhat.com/platform"
 )
 


### PR DESCRIPTION
It seems like for some objects we are getting some char limit restrictions. Even though having the component in the name of the PipelineRun and in the config map might be useful for debugging reasons, we cannot really be sure that it won't contain a too long character. Due to this reason, let's remove the component name.