### PR TITLE
Remove ownership for the caConfigMap

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -310,16 +310,6 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(comp component.GitCo
 		return nil, err
 	}
 
-	// ownership for the caConfigMap
-	if caConfigMap != nil {
-		if err := controllerutil.SetOwnerReference(pipelineRun, caConfigMap, r.Scheme); err != nil {
-			return nil, err
-		}
-		if err := r.Client.Update(ctx, caConfigMap); err != nil {
-			return nil, err
-		}
-	}
-
 	return pipelineRun, nil
 }
 


### PR DESCRIPTION
The ca-bundle configmap should not be owned by any pipelinerun, as it is shared by all PipelineRuns.