### PR TITLE
Run the docker manager everyday

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -103,7 +103,7 @@
   "dockerfile": {
     "enabled": true,
     "schedule": [
-      "after 5am on monday"
+      "before 5am"
     ]
   },
   "rpm": {


### PR DESCRIPTION
Many Pipeline get triggered (and a lot of builds as a consequence) when MintMaker runs and creates many PRs. If a major container image that is used by many other container images gets released, we might end up with a lot of new Pipelines running at the same time. This happened on Monday because that's when we run the docker manager. As a temporary solution we can run the docker manager everyday, so that when there's such a release, we aren't also triggering all the container images that were released during the previous week, that don't have anything to do with that major container image. The long term solution is to improve the scheduling in some smarter way.