### PR TITLE
Set GOTOOLCHAIN for Renovate's child processes

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -13,6 +13,9 @@
   "inheritConfig": true,
   "platformCommit": "enabled",
   "autodiscover": false,
+  "customEnvVariables": {
+    "GOTOOLCHAIN": "auto"
+  },
   "vulnerabilityAlerts": {
     "enabled": false
   },


### PR DESCRIPTION
Docs: https://docs.renovatebot.com/self-hosted-configuration/#customenvvariables

I was confused why some env variables were available to Renovate and some not. Turns out, some are hardcoded ([env.ts](https://github.com/renovatebot/renovate/blob/main/lib/util/exec/env.ts)) to be inherited from outside and the rest needs to go in `customEnvVariables`. This seems like a good protection against leaking secrets.