### PR TITLE
renovate: disable pruneStaleBranches to prevent PR auto-closing

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -13,6 +13,7 @@
   "inheritConfig": true,
   "platformCommit": "enabled",
   "autodiscover": false,
+  "pruneStaleBranches": false,
   "customEnvVariables": {
     "GOTOOLCHAIN": "auto"
   },


### PR DESCRIPTION
Since migrating to "one pipelinerun per component", mintmaker runs renovate against single branches individually. This causes renovate to incorrectly consider other branches as stale and attempt to prune its own branches and PRs, resulting in PRs being repeatedly opened and closed.

Set pruneStaleBranches to false to maintain PRs across single-branch scans.

ref: https://docs.renovatebot.com/configuration-options/#prunestalebranches