### PR TITLE
Read renovate image from env var

### DIFF
--- a/internal/pkg/common/constants.go
+++ b/internal/pkg/common/constants.go
@@ -1,0 +1,6 @@
+package common
+
+const (
+	RenovateImageEnvName    = "RENOVATE_IMAGE"
+	DefaultRenovateImageURL = "quay.io/konflux-ci/mintmaker-renovate-image:latest"
+)


### PR DESCRIPTION
Allow customization of renovate image via environment variable. Falls back to default `latest` tag if not specified.