### PR TITLE
renovate: remove concurrent branch limit

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -14,6 +14,7 @@
   "platformCommit": "enabled",
   "autodiscover": false,
   "pruneStaleBranches": false,
+  "branchConcurrentLimit": 0,
   "customEnvVariables": {
     "GOTOOLCHAIN": "auto"
   },


### PR DESCRIPTION
The default `config:recommended` preset limits concurrent branches to 10. Since we disabled `pruneStaleBranches` in 2fe98b9, Renovate no longer automatically closes stale branches. This can cause the concurrent limit to be reached when old Renovate branches accumulate. Remove the limit to prevent blocking new updates.