### PR TITLE
Introduce OSV database to the PipelineRuns

### DIFF
--- a/internal/pkg/tekton/pipeline_run_builder.go
+++ b/internal/pkg/tekton/pipeline_run_builder.go
@@ -107,12 +107,41 @@ func NewPipelineRunBuilder(name, namespace string) *PipelineRunBuilder {
 			Spec: tektonv1.PipelineRunSpec{
 				Status: tektonv1.PipelineRunSpecStatusPending,
 				PipelineSpec: &tektonv1.PipelineSpec{
+					Workspaces: []tektonv1.PipelineWorkspaceDeclaration{
+						{
+							Name: "shared-db",
+						},
+					},
 					Tasks: []tektonv1.PipelineTask{
 						{
 							Name: "build",
+							Workspaces: []tektonv1.WorkspacePipelineTaskBinding{
+								{
+									Name:      "shared-db",
+									Workspace: "shared-db",
+								},
+							},
 							TaskSpec: &tektonv1.EmbeddedTask{
 								TaskSpec: tektonv1.TaskSpec{
+									Workspaces: []tektonv1.WorkspaceDeclaration{
+										{
+											Name: "shared-db",
+										},
+									},
 									Steps: []tektonv1.Step{
+										{
+											Name:   "prepare-db",
+											Image:  "quay.io/konflux-ci/mintmaker-osv-database:latest",
+											Script: "cp -r /data/osv-db /workspace/shared-db",
+											SecurityContext: &corev1.SecurityContext{
+												Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+												RunAsNonRoot:             ptr.To(true),
+												AllowPrivilegeEscalation: ptr.To(false),
+												SeccompProfile: &corev1.SeccompProfile{
+													Type: corev1.SeccompProfileTypeRuntimeDefault,
+												},
+											},
+										},
 										{
 											Name:   "renovate",
 											Image:  renovateImageURL,
@@ -132,7 +161,7 @@ func NewPipelineRunBuilder(name, namespace string) *PipelineRunBuilder {
 												},
 												Limits: corev1.ResourceList{
 													"cpu":    resource.MustParse("300m"),
-													"memory": resource.MustParse("1Gi"),
+													"memory": resource.MustParse("2Gi"),
 												},
 											},
 											Env: []corev1.EnvVar{
@@ -148,12 +177,26 @@ func NewPipelineRunBuilder(name, namespace string) *PipelineRunBuilder {
 													Name:  "LOG_LEVEL",
 													Value: "debug",
 												},
+												{
+													Name:  "OSV_OFFLINE_DISABLE_DOWNLOAD",
+													Value: "true",
+												},
+												{
+													Name:  "OSV_OFFLINE_ROOT_DIR",
+													Value: "/workspace/shared-db/osv-db",
+												},
 											},
 										},
 									},
 								},
 							},
 						},
+					},
+				},
+				Workspaces: []tektonv1.WorkspaceBinding{
+					{
+						Name:     "shared-db",
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
 				},
 			},


### PR DESCRIPTION
PipelineRuns will now have two tasks and a shared persistent volume. The first task copies the OSV DB from the periodically built DB image to the shared volume. The second task runs renovate and can utilize the OSV database in its run. New env variables were added to specify the DB location and disable the download of the upstream DB. The created persistent volume is deleted along with the PipelineRun.

I have increased the memory requirements to 2Gi because I ran into OOM issues when testing with 1Gi of memory. The reason is most likely that the DB is loaded into memory during execution, which increases the memory foorprint by up to ~500MB. It's possible that 2Gi is an overkill, but I haven't tested the safe threshold more closely.