### PR TITLE
Enable container CVE remediation

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -19,6 +19,9 @@
   "customEnvVariables": {
     "GOTOOLCHAIN": "auto"
   },
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
   "additionalBranchPrefix": "{{baseBranch}}/",
   "branchPrefix": "konflux/mintmaker/",
   "enabledManagers": [


### PR DESCRIPTION
Setting containerVulnerabilityAlerts enables the new functionality. vulnerabilityAlerts configuration is removed because it prevents the vulnerability PRs from being created.