### PR TITLE
Enable gitlabci manager

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -64,7 +64,9 @@
     "runtime-version",
     "setup-cfg",
     "gomod",
-    "ocb"
+    "ocb",
+    "gitlabci",
+    "gitlabci-include"
   ],
   "tekton": {
     "additionalBranchPrefix": "",
@@ -209,6 +211,16 @@
     ]
   },
   "kustomize": {
+    "schedule": [
+      "after 5am on wednesday"
+    ]
+  },
+  "gitlabci": {
+    "schedule": [
+      "after 5am on wednesday"
+    ]
+  },
+  "gitlabci-include": {
     "schedule": [
       "after 5am on wednesday"
     ]


### PR DESCRIPTION
We can safely enable these two managers since we just got a user last week with successful runs and I also added E2E tests for these.