### PR TITLE
Update RPM OSV database generator for osv-offline compatibility

### DIFF
--- a/tools/osv-generator/cve_parser.go
+++ b/tools/osv-generator/cve_parser.go
@@ -143,13 +143,13 @@ func getAffectedListRPMs(vex VEX) []*Affected {
 					}
 
 					// Parse name and version from pURL
-					re := regexp.MustCompile(`pkg:rpm(?:mod)?/([^@]+)@([^?]+)`)
+					re := regexp.MustCompile(`(pkg:rpm(?:mod)?/(?:redhat/)?([^@]+))@([^?]+)`)
 					matches := re.FindStringSubmatch(subSubBranch.Product.ProductIdentificationHelper.Purl)
-					purl, packageName, version := matches[0], matches[1], matches[2]
+					purl, packageName, version := matches[1], matches[2], matches[3]
 
 					affectedPackage := Affected{
 						Package: &Package{
-							Ecosystem: "Red Hat",
+							Ecosystem: "RPM",
 							Name:      packageName,
 							Purl:      purl,
 						},

--- a/tools/osv-generator/cve_parser_test.go
+++ b/tools/osv-generator/cve_parser_test.go
@@ -55,7 +55,7 @@ var vexSampleFile = []byte(`{
                 "branches": [{
                     "product": {
                         "product_identification_helper": {
-                            "purl": "pkg:rpm/testpackage@1.0.1?arch=x86_64"
+                            "purl": "pkg:rpm/redhat/testpackage@1.0.1?arch=x86_64"
                         }
                     }
                 }, {
@@ -102,8 +102,8 @@ func TestGetAffectedListRPMs(t *testing.T) {
 	if affectedList[0].Package.Name != "testpackage" {
 		t.Fatalf("expected testpackage, got %s", affectedList[0].Package.Name)
 	}
-	if affectedList[0].Package.Purl != "pkg:rpm/testpackage@1.0.1" {
-		t.Fatalf("expected pkg:rpm/testpackage@1.0.0, got %s", affectedList[0].Package.Purl)
+	if affectedList[0].Package.Purl != "pkg:rpm/redhat/testpackage" {
+		t.Fatalf("expected pkg:rpm/redhat/testpackage, got %s", affectedList[0].Package.Purl)
 	}
 }
 

--- a/tools/osv-generator/generator_test.go
+++ b/tools/osv-generator/generator_test.go
@@ -30,7 +30,7 @@ var sampleCSV = []byte(`2023/rhsa-2023_6919.json,2024-12-02T08:22:15+00:00
 2022/rhsa-2022_5249.json,2024-12-02T07:52:17+00:00
 2024/rhsa-2024_5439.json,2024-12-02T07:52:10+00:00`)
 
-var sampleOSVResultRPMs = `{"_id":"abcd","schema_version":"1.6.0","id":"CVE","database_specific":{"severity":"Moderate","cwe_ids":["CWE"]},"published":"2024-08-20T10:54:54Z","summary":"summary","details":"description","affected":[{"package":{"ecosystem":"Red Hat","name":"redhat/openstack","purl":"pkg:rpm/redhat/openstack@2.0.0"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0.0.0"},{"fixed":"2.0.0"}]}]}],"references":[{"type":"WEB","url":"fake-url"}]}`
+var sampleOSVResultRPMs = `{"_id":"abcd","schema_version":"1.6.0","id":"CVE","database_specific":{"severity":"Moderate","cwe_ids":["CWE"]},"published":"2024-08-20T10:54:54Z","summary":"summary","details":"description","affected":[{"package":{"ecosystem":"RPM","name":"openstack","purl":"pkg:rpm/redhat/openstack"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0.0.0"},{"fixed":"2.0.0"}]}]}],"references":[{"type":"WEB","url":"fake-url"}]}`
 var sampleOSVResultContainers = `{"_id":"abcd","schema_version":"1.6.0","id":"CVE","database_specific":{"severity":"Moderate","cwe_ids":["CWE"]},"published":"2024-08-20T10:54:54Z","summary":"summary","details":"description","affected":[{"package":{"ecosystem":"Docker","name":"some-registry.com/org/repo","purl":"pkg:oci/test-image@sha256:abcd?arch=amd64\u0026repository_url=some-registry.com/org/repo\u0026tag=v1"},"ranges":[]}],"references":[{"type":"WEB","url":"fake-url"}]}`
 
 func TestGetAdvisoryListByModified(t *testing.T) {


### PR DESCRIPTION
- update Purl to remove version strings
- change Ecosystem from `Red Hat` to `RPM`
- remove `redhat/` prefix from package name