### PR TITLE
Configure Renovate to only update image digests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,9 +9,11 @@
     "packageRules": [
       {
         "matchPackageNames": [
-          "registry.access.redhat.com/ubi9/go-toolset"
+          "registry.access.redhat.com/ubi9/go-toolset",
+          "registry.access.redhat.com/ubi9/ubi-minimal"
         ],
-        "allowedVersions": "<=1.21"
+        "matchUpdateTypes": ["major", "minor", "patch"],
+        "enabled": false
       }
     ]
   }


### PR DESCRIPTION
Configure Renovate to disable version updates (major/minor/patch) for used images while keeping digest updates enabled.