### PR TITLE
Fix regex in allowed commands

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -360,7 +360,7 @@
   "forkProcessing": "enabled",
   "allowedCommands": [
     "^rpm-lockfile-prototype rpms.in.yaml$",
-    "^pipeline-migration-tool -u '\\[{{#each upgrades}}{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"currentDigest\": \"{{{currentDigest}}}\", \"newValue\": \"{{{newValue}}}\", \"newDigest\": \"{{{newDigest}}}\", \"packageFile\": \"{{{packageFile}}}\", \"parentDir\": \"{{{parentDir}}}\", \"depTypes\": \\[{{#each depTypes}}\"{{{this}}}\"{{#unless @last}},{{\/unless}}{{\/each}}\\]}{{#unless @last}},{{\/unless}}{{\/each}}\\]'$"
+    "^pipeline-migration-tool -u '\\[\\{\\{#each upgrades\\}\\}\\{\"depName\": \"\\{\\{\\{depName\\}\\}\\}\", \"currentValue\": \"\\{\\{\\{currentValue\\}\\}\\}\", \"currentDigest\": \"\\{\\{\\{currentDigest\\}\\}\\}\", \"newValue\": \"\\{\\{\\{newValue\\}\\}\\}\", \"newDigest\": \"\\{\\{\\{newDigest\\}\\}\\}\", \"packageFile\": \"\\{\\{\\{packageFile\\}\\}\\}\", \"parentDir\": \"\\{\\{\\{parentDir\\}\\}\\}\", \"depTypes\": \\[\\{\\{#each depTypes\\}\\}\"\\{\\{\\{this\\}\\}\\}\"\\{\\{#unless @last\\}\\},\\{\\{\\/unless\\}\\}\\{\\{\\/each\\}\\}\\]\\}\\{\\{#unless @last\\}\\},\\{\\{\\/unless\\}\\}\\{\\{\\/each\\}\\}\\]'$"
   ],
   "updateNotScheduled": false,
   "dependencyDashboard": false,


### PR DESCRIPTION
Tekton manager currently shows artifact update problem because it cannot run the post upgrade migration script. This is because the script was not escaped correctly in allowed commands (Renovate uses ECMAScript flavor of regex). The extremely long string in the PR fixes it.

Closes [CWFHEALTH-4045](https://issues.redhat.com/browse/CWFHEALTH-4045)