### PR TITLE
Fix PR titles for single RPM dependency updates

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -139,6 +139,7 @@
         "groupName": "RPM updates",
         "commitMessageAction": "",
         "commitMessageTopic": "RPM updates",
+        "commitMessageExtra": "",
         "matchManagers": [
           "rpm"
         ]


### PR DESCRIPTION
Before this change, if there was only one RPM updated, the title would be `RPM updates to <version> [SECURITY]` which doesn't make sense, because the name of the dependency isn't there.