### PR TITLE
Remove semanticCommits from packageRules

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -93,7 +93,6 @@
           "commitMessageTopic": "{{{groupName}}}"
         },
         "commitMessageTopic": "Konflux references",
-        "semanticCommits": "enabled",
         "prBodyColumns": [
           "Package",
           "Change",


### PR DESCRIPTION
This option doesn't do anything unless it's on top level. The default is `auto` ([docs](https://docs.renovatebot.com/configuration-options/#semanticcommits)), which detects, whether semantic commits are used in the project using [conventional-commits-detector](https://www.npmjs.com/package/conventional-commits-detector).

Renovate uses the last 20 commit messages to detect that. Up until now, if it looked like this option worked, it didn't. It just detected semantic commits automatically. Until we found a repo where it didn't work :smile: . So if it doesn't detect correctly, users need to set it explicitly to either `enabled` or `disabled`.