### PR TITLE
Move gomod packageRule to the correct place

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -104,15 +104,6 @@
         "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
         "recreateWhen": "always",
         "rebaseWhen": "behind-base-branch"
-      },
-      {
-        "matchManagers": [
-          "gomod"
-        ],
-        "matchDepTypes": [
-          "indirect"
-        ],
-        "enabled": true
       }
     ],
     "schedule": [
@@ -357,6 +348,17 @@
     "postUpdateOptions": [
       "gomodUpdateImportPaths",
       "gomodTidy"
+    ],
+    "packageRules": [
+      {
+        "matchManagers": [
+          "gomod"
+        ],
+        "matchDepTypes": [
+          "indirect"
+        ],
+        "enabled": true
+      }
     ]
   },
   "ocb": {


### PR DESCRIPTION
I don't know why it was under `tekton`, but it should be next to `gomod`