### PR TITLE
feat: set PipelineRun timeout to 1 hour

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -258,7 +258,8 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(comp component.GitCo
 			"mintmaker.appstudio.redhat.com/git-platform":        comp.GetPlatform(), // (github, gitlab)
 			"mintmaker.appstudio.redhat.com/git-host":            comp.GetHost(),     // github.com, gitlab.com, gitlab.other.com
 			"mintmaker.appstudio.redhat.com/reconcile-timestamp": strconv.FormatInt(comp.GetTimestamp(), 10),
-		})
+		}).
+        WithTimeouts(nil)
 	builder.WithServiceAccount("mintmaker-controller-manager")
 
 	cmItems := []corev1.KeyToPath{

--- a/internal/pkg/tekton/pipeline_run_builder.go
+++ b/internal/pkg/tekton/pipeline_run_builder.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"time"
 	"unicode"
 
 	"github.com/hashicorp/go-multierror"
@@ -445,7 +446,10 @@ func (b *PipelineRunBuilder) WithServiceAccount(serviceAccount string) *Pipeline
 }
 
 // WithTimeouts sets the Timeouts for the PipelineRun.
-func (b *PipelineRunBuilder) WithTimeouts(timeouts, defaultTimeouts *tektonv1.TimeoutFields) *PipelineRunBuilder {
+func (b *PipelineRunBuilder) WithTimeouts(timeouts *tektonv1.TimeoutFields) *PipelineRunBuilder {
+	defaultTimeouts := &tektonv1.TimeoutFields{
+		Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
+	}
 	if timeouts == nil || *timeouts == (tektonv1.TimeoutFields{}) {
 		b.pipelineRun.Spec.Timeouts = defaultTimeouts
 	} else {

--- a/internal/pkg/tekton/pipeline_run_builder_test.go
+++ b/internal/pkg/tekton/pipeline_run_builder_test.go
@@ -271,10 +271,8 @@ var _ = Describe("PipelineRun builder", func() {
 			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
 			timeouts := &tektonv1.TimeoutFields{
 				Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
-				Tasks:    &metav1.Duration{Duration: 1 * time.Hour},
-				Finally:  &metav1.Duration{Duration: 1 * time.Hour},
 			}
-			builder.WithTimeouts(timeouts, nil)
+			builder.WithTimeouts(timeouts)
 			Expect(builder.pipelineRun.Spec.Timeouts).To(Equal(timeouts))
 		})
 
@@ -282,10 +280,8 @@ var _ = Describe("PipelineRun builder", func() {
 			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
 			defaultTimeouts := &tektonv1.TimeoutFields{
 				Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
-				Tasks:    &metav1.Duration{Duration: 1 * time.Hour},
-				Finally:  &metav1.Duration{Duration: 1 * time.Hour},
 			}
-			builder.WithTimeouts(nil, defaultTimeouts)
+			builder.WithTimeouts(nil)
 			Expect(builder.pipelineRun.Spec.Timeouts).To(Equal(defaultTimeouts))
 		})
 	})


### PR DESCRIPTION
Set the PipelineRun timeout to 1 hour instead of relying on the default value from the Tekton Pipelines controller. This duration should provide sufficient time for Renovate jobs while preventing excessive runtime if something goes wrong.