### PR TITLE
Remove timestamp field from component struct

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -19,16 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
-	"strconv"
 	"time"
 
-	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
-	mmv1alpha1 "github.com/konflux-ci/mintmaker/api/v1alpha1"
-	"github.com/konflux-ci/mintmaker/internal/pkg/component"
-	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
-	"github.com/konflux-ci/mintmaker/internal/pkg/tekton"
-	"github.com/konflux-ci/mintmaker/internal/pkg/utils"
-	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +32,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+
+	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+
+	mmv1alpha1 "github.com/konflux-ci/mintmaker/api/v1alpha1"
+	"github.com/konflux-ci/mintmaker/internal/pkg/component"
+	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
+	"github.com/konflux-ci/mintmaker/internal/pkg/tekton"
+	"github.com/konflux-ci/mintmaker/internal/pkg/utils"
 )
 
 // DependencyUpdateCheckReconciler reconciles a DependencyUpdateCheck object
@@ -145,8 +147,8 @@ func (r *DependencyUpdateCheckReconciler) createMergedPullSecret(ctx context.Con
 		return nil, err
 	}
 
-	timestamp := time.Now().Unix()
-	name := fmt.Sprintf("renovate-image-pull-secrets-%d-%s", timestamp, utils.RandomString(5))
+	timestamp := time.Now().UTC().Format("01021504") // MMDDhhmm, from Go's time formatting reference date "20060102150405"
+	name := fmt.Sprintf("renovate-image-pull-secrets-%s-%s", timestamp, utils.RandomString(5))
 
 	newSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -167,7 +169,7 @@ func (r *DependencyUpdateCheckReconciler) createMergedPullSecret(ctx context.Con
 }
 
 // createPipelineRun creates and returns a new PipelineRun
-func (r *DependencyUpdateCheckReconciler) createPipelineRun(comp component.GitComponent, ctx context.Context, registrySecret *corev1.Secret) (*tektonv1.PipelineRun, error) {
+func (r *DependencyUpdateCheckReconciler) createPipelineRun(name string, comp component.GitComponent, ctx context.Context, registrySecret *corev1.Secret) (*tektonv1.PipelineRun, error) {
 
 	log := ctrllog.FromContext(ctx).WithName("DependencyUpdateCheckController")
 	ctx = ctrllog.IntoContext(ctx, log)
@@ -181,8 +183,6 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(comp component.GitCo
 			}
 		}
 	}()
-
-	name := fmt.Sprintf("renovate-%d-%s", comp.GetTimestamp(), utils.RandomString(8))
 
 	renovateConfig, err := comp.GetRenovateConfig(registrySecret)
 	if err != nil {
@@ -252,14 +252,13 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(comp component.GitCo
 	// Creating the pipelineRun definition
 	builder := tekton.NewPipelineRunBuilder(name, MintMakerNamespaceName).
 		WithLabels(map[string]string{
-			"mintmaker.appstudio.redhat.com/application":         comp.GetApplication(),
-			"mintmaker.appstudio.redhat.com/component":           comp.GetName(),
-			"mintmaker.appstudio.redhat.com/namespace":           comp.GetNamespace(),
-			"mintmaker.appstudio.redhat.com/git-platform":        comp.GetPlatform(), // (github, gitlab)
-			"mintmaker.appstudio.redhat.com/git-host":            comp.GetHost(),     // github.com, gitlab.com, gitlab.other.com
-			"mintmaker.appstudio.redhat.com/reconcile-timestamp": strconv.FormatInt(comp.GetTimestamp(), 10),
+			"mintmaker.appstudio.redhat.com/application":  comp.GetApplication(),
+			"mintmaker.appstudio.redhat.com/component":    comp.GetName(),
+			"mintmaker.appstudio.redhat.com/namespace":    comp.GetNamespace(),
+			"mintmaker.appstudio.redhat.com/git-platform": comp.GetPlatform(), // (github, gitlab)
+			"mintmaker.appstudio.redhat.com/git-host":     comp.GetHost(),     // github.com, gitlab.com, gitlab.other.com
 		}).
-        WithTimeouts(nil)
+		WithTimeouts(nil)
 	builder.WithServiceAccount("mintmaker-controller-manager")
 
 	cmItems := []corev1.KeyToPath{
@@ -455,9 +454,9 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 	// Track components for which we already created a PipelineRun
 	processedComponents := make([]string, 0)
 
-	timestamp := time.Now().UTC().Unix()
+	timestamp := time.Now().UTC().Format("01021504") // MMDDhhmm, from Go's time formatting reference date "20060102150405"
 	for _, appstudioComponent := range componentList {
-		comp, err := component.NewGitComponent(&appstudioComponent, timestamp, r.Client, ctx)
+		comp, err := component.NewGitComponent(&appstudioComponent, r.Client, ctx)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("failed to handle component: %s", appstudioComponent.Name))
 			continue
@@ -479,7 +478,8 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 		}
 
 		log.Info(fmt.Sprintf("creating pending PipelineRun for %s", key))
-		pipelinerun, err := r.createPipelineRun(comp, ctx, registrySecret)
+		plrName := fmt.Sprintf("renovate-%s-%s", timestamp, utils.RandomString(8))
+		pipelinerun, err := r.createPipelineRun(plrName, comp, ctx, registrySecret)
 		if err != nil {
 			log.Info(fmt.Sprintf("failed to create PipelineRun for %s: %s", appstudioComponent.Name, err.Error()))
 		} else {

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -18,12 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strconv"
 
-	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
-	github "github.com/konflux-ci/mintmaker/internal/pkg/component/github"
-	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
-	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,12 +28,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+
+	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+
+	github "github.com/konflux-ci/mintmaker/internal/pkg/component/github"
+	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
 )
 
 var (
 	MaxSimultaneousPipelineRuns      = 20
 	MintMakerGitPlatformLabel        = "mintmaker.appstudio.redhat.com/git-platform"
-	MintMakerReconcileTimestampLabel = "mintmaker.appstudio.redhat.com/reconcile-timestamp"
 	MintMakerComponentNameLabel      = "mintmaker.appstudio.redhat.com/component"
 	MintMakerComponentNamespaceLabel = "mintmaker.appstudio.redhat.com/namespace"
 )
@@ -144,12 +145,7 @@ func (r *PipelineRunReconciler) startPipelineRun(plr tektonv1.PipelineRun, ctx c
 		return false
 	}
 
-	timestamp, err := strconv.ParseInt(plr.Labels[MintMakerReconcileTimestampLabel], 10, 64)
-	if err != nil {
-		return false
-	}
-
-	ghComponent, err = github.NewComponent(&component, timestamp, r.Client, ctx)
+	ghComponent, err = github.NewComponent(&component, r.Client, ctx)
 	if err != nil {
 		return false
 	}

--- a/internal/controller/pipelinerun_controller_test.go
+++ b/internal/controller/pipelinerun_controller_test.go
@@ -94,7 +94,6 @@ var _ = Describe("PipelineRun Controller", FlakeAttempts(5), func() {
 			MintMakerGitPlatformLabel:        "github",
 			MintMakerComponentNameLabel:      "testcomp",
 			MintMakerComponentNamespaceLabel: "testnamespace",
-			MintMakerReconcileTimestampLabel: "01234",
 		}
 
 		_ = BeforeEach(func() {

--- a/internal/pkg/component/base/base.go
+++ b/internal/pkg/component/base/base.go
@@ -23,13 +23,13 @@ import (
 	"strings"
 	"sync"
 
-	bslices "github.com/konflux-ci/mintmaker/internal/pkg/slices"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logger "sigs.k8s.io/controller-runtime/pkg/log"
+
+	bslices "github.com/konflux-ci/mintmaker/internal/pkg/slices"
 )
 
 var (
@@ -48,7 +48,6 @@ type BaseComponent struct {
 	// Temporary field to make the implementation easy, it's part of GitURL, so they're duplicated
 	Repository string
 	Branch     string
-	Timestamp  int64
 }
 
 func (c *BaseComponent) GetName() string {
@@ -77,10 +76,6 @@ func (c *BaseComponent) GetGitURL() string {
 
 func (c *BaseComponent) GetRepository() string {
 	return c.Repository
-}
-
-func (c *BaseComponent) GetTimestamp() int64 {
-	return c.Timestamp
 }
 
 type HostRule map[string]string

--- a/internal/pkg/component/component.go
+++ b/internal/pkg/component/component.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+
 	github "github.com/konflux-ci/mintmaker/internal/pkg/component/github"
 	gitlab "github.com/konflux-ci/mintmaker/internal/pkg/component/gitlab"
 	utils "github.com/konflux-ci/mintmaker/internal/pkg/utils"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type GitComponent interface {
@@ -34,7 +36,6 @@ type GitComponent interface {
 	GetHost() string
 	GetGitURL() string
 	GetRepository() string
-	GetTimestamp() int64
 	GetToken() (string, error)
 	GetBranch() (string, error)
 	GetAPIEndpoint() string
@@ -42,7 +43,7 @@ type GitComponent interface {
 	GetRPMActivationKey(client.Client, context.Context) (string, string, error)
 }
 
-func NewGitComponent(comp *appstudiov1alpha1.Component, timestamp int64, client client.Client, ctx context.Context) (GitComponent, error) {
+func NewGitComponent(comp *appstudiov1alpha1.Component, client client.Client, ctx context.Context) (GitComponent, error) {
 	// TODO: validate git URL
 	platform, err := utils.GetGitPlatform(comp.Spec.Source.GitSource.URL)
 	if err != nil {
@@ -51,13 +52,13 @@ func NewGitComponent(comp *appstudiov1alpha1.Component, timestamp int64, client 
 
 	switch platform {
 	case "github":
-		c, err := github.NewComponent(comp, timestamp, client, ctx)
+		c, err := github.NewComponent(comp, client, ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error creating git component: %w", err)
 		}
 		return c, nil
 	case "gitlab":
-		c, err := gitlab.NewComponent(comp, timestamp, client, ctx)
+		c, err := gitlab.NewComponent(comp, client, ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error creating git component: %w", err)
 		}

--- a/internal/pkg/component/github/github.go
+++ b/internal/pkg/component/github/github.go
@@ -86,7 +86,7 @@ func getAppIDAndKey(client client.Client, ctx context.Context) (int64, []byte, e
 	return ghAppID, ghAppPrivateKey, nil
 }
 
-func NewComponent(comp *appstudiov1alpha1.Component, timestamp int64, client client.Client, ctx context.Context) (*Component, error) {
+func NewComponent(comp *appstudiov1alpha1.Component, client client.Client, ctx context.Context) (*Component, error) {
 	appID, appPrivateKey, err := getAppIDAndKey(client, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get GitHub APP ID and private key: %w", err)
@@ -115,7 +115,6 @@ func NewComponent(comp *appstudiov1alpha1.Component, timestamp int64, client cli
 			Host:        host,
 			GitURL:      giturl,
 			Repository:  repository,
-			Timestamp:   timestamp,
 			Branch:      comp.Spec.Source.GitSource.Revision,
 		},
 		AppID:         appID,

--- a/internal/pkg/component/gitlab/gitlab.go
+++ b/internal/pkg/component/gitlab/gitlab.go
@@ -21,14 +21,16 @@ import (
 	"net/url"
 	"strings"
 
-	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
-	"github.com/konflux-ci/mintmaker/internal/pkg/component/base"
-	bslices "github.com/konflux-ci/mintmaker/internal/pkg/slices"
-	"github.com/konflux-ci/mintmaker/internal/pkg/utils"
 	"github.com/xanzy/go-gitlab"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+
+	"github.com/konflux-ci/mintmaker/internal/pkg/component/base"
+	bslices "github.com/konflux-ci/mintmaker/internal/pkg/slices"
+	"github.com/konflux-ci/mintmaker/internal/pkg/utils"
 )
 
 //TODO: doc about only supporting GitHub with the installed GitHub App
@@ -44,7 +46,7 @@ type Repository struct {
 	Repository   string
 }
 
-func NewComponent(comp *appstudiov1alpha1.Component, timestamp int64, client client.Client, ctx context.Context) (*Component, error) {
+func NewComponent(comp *appstudiov1alpha1.Component, client client.Client, ctx context.Context) (*Component, error) {
 	giturl := comp.Spec.Source.GitSource.URL
 	// TODO: a helper to validate and parse the git url
 	platform, err := utils.GetGitPlatform(giturl)
@@ -69,7 +71,6 @@ func NewComponent(comp *appstudiov1alpha1.Component, timestamp int64, client cli
 			Host:        host,
 			GitURL:      giturl,
 			Repository:  repository,
-			Timestamp:   timestamp,
 			Branch:      comp.Spec.Source.GitSource.Revision,
 		},
 		client: client,


### PR DESCRIPTION
The timestamp was previously used for implementing the refreshing of GitHub App installation cache. Since the cache is now refreshed based on time, we no longer need to store timestamp information in the component struct.

Additionally, changed the timestamp in PipelineRun name from Unix timestamp format to MMDDhhmm, making it more human-readable.