### PR TITLE
Grouping Go updates from Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,5 +16,18 @@
         "enabled": false
       }
     ]
+  },
+  "gomod": {
+    "packageRules": [
+      {
+        "matchDatasources": ["go"],
+        "enabled": true,
+        "groupName": "Go updates",
+        "group": {
+          "branchTopic": "go-updates",
+          "commitMessageTopic": "go packages"
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
Configure Renovate to group all Go module dependency updates into a single PR, so it will be easy for reviewing and testing.