### PR TITLE
Enable Red Hat versioning of container images by default

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -122,6 +122,27 @@
       "before 5am"
     ]
   },
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "registry.access.redhat.com/rhel",
+        "registry.access.redhat.com/rhel-atomic",
+        "registry.access.redhat.com/rhel-init",
+        "registry.access.redhat.com/rhel-minimal",
+        "registry.access.redhat.com/rhceph/**",
+        "registry.access.redhat.com/rhgs3/**",
+        "registry.access.redhat.com/rhel7**",
+        "registry.access.redhat.com/rhel8/**",
+        "registry.access.redhat.com/rhel9/**",
+        "registry.access.redhat.com/rhscl/**",
+        "registry.access.redhat.com/ubi*{,/}**",
+        "redhat/**",
+        "registry.redhat.io/*",
+        "registry.stage.redhat.io/*"
+      ],
+      "versioning": "redhat"
+    }
+  ],
   "rpm": {
     "enabled": true,
     "packageRules": [


### PR DESCRIPTION
This is from https://github.com/konflux-ci/mintmaker-presets/pull/3, it makes more sense to enable by default instead of having the preset.