### PR TITLE
Configure renovate to use Redis cache

### DIFF
--- a/internal/pkg/tekton/pipeline_run_builder.go
+++ b/internal/pkg/tekton/pipeline_run_builder.go
@@ -213,6 +213,14 @@ func NewPipelineRunBuilder(name, namespace string) *PipelineRunBuilder {
 													Name:  "DNF_VAR_SSL_CLIENT_CERT",
 													Value: "/workspace/shared-data/rpm-certs/cert.pem",
 												},
+												{
+													Name:  "RENOVATE_REDIS_PREFIX",
+													Value: "renovate-global-cache",
+												},
+												{
+													Name:  "RENOVATE_REDIS_URL",
+													Value: "redis://redis:6379",
+												},
 											},
 										},
 									},


### PR DESCRIPTION
The config options (as described in [1]) are set with environment variables.

[1] https://docs.renovatebot.com/self-hosted-configuration/#redisprefix