### PR TITLE
Export availability metric

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,6 +5,7 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: mintmaker
     app.kubernetes.io/managed-by: kustomize
+    openshift.io/cluster-monitoring: "true"
   name: system
 ---
 apiVersion: apps/v1

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -35,6 +35,7 @@ import (
 
 	github "github.com/konflux-ci/mintmaker/internal/pkg/component/github"
 	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
+	mmmetrics "github.com/konflux-ci/mintmaker/internal/pkg/metrics"
 )
 
 var (
@@ -194,6 +195,7 @@ func (r *PipelineRunReconciler) launchUpToNPipelineRuns(numToLaunch int, existin
 			success := r.startPipelineRun(pipelineRun, ctx)
 			if success {
 				numLaunched += 1
+				mmmetrics.CountScheduledRuns()
 			}
 			if numLaunched == numToLaunch {
 				break

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -35,7 +35,7 @@ import (
 
 	github "github.com/konflux-ci/mintmaker/internal/pkg/component/github"
 	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
-	mmmetrics "github.com/konflux-ci/mintmaker/internal/pkg/metrics"
+	mintmakermetrics "github.com/konflux-ci/mintmaker/internal/pkg/metrics"
 )
 
 var (
@@ -195,7 +195,7 @@ func (r *PipelineRunReconciler) launchUpToNPipelineRuns(numToLaunch int, existin
 			success := r.startPipelineRun(pipelineRun, ctx)
 			if success {
 				numLaunched += 1
-				mmmetrics.CountScheduledRuns()
+				mintmakermetrics.CountScheduledRuns()
 			}
 			if numLaunched == numToLaunch {
 				break

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -195,7 +195,9 @@ func (r *PipelineRunReconciler) launchUpToNPipelineRuns(numToLaunch int, existin
 			success := r.startPipelineRun(pipelineRun, ctx)
 			if success {
 				numLaunched += 1
-				mintmakermetrics.CountScheduledRuns()
+				mintmakermetrics.CountScheduledRunSuccess()
+			} else {
+				mintmakermetrics.CountScheduledRunFailure()
 			}
 			if numLaunched == numToLaunch {
 				break

--- a/internal/pkg/metrics/backend_probe.go
+++ b/internal/pkg/metrics/backend_probe.go
@@ -1,0 +1,25 @@
+package mmmetrics
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type BackendProbe struct {
+	scheduledRuns atomic.Int32
+}
+
+func NewBackendProbe() AvailabilityProbe {
+	return &BackendProbe{
+		scheduledRuns: atomic.Int32{},
+	}
+}
+
+func (q *BackendProbe) CheckEvents(_ context.Context) float64 {
+	defer q.scheduledRuns.Store(0)
+	return float64(q.scheduledRuns.Load())
+}
+
+func (q *BackendProbe) AddEvent() {
+	q.scheduledRuns.Add(1)
+}

--- a/internal/pkg/metrics/backend_probe.go
+++ b/internal/pkg/metrics/backend_probe.go
@@ -1,4 +1,4 @@
-package mmmetrics
+package mintmakermetrics
 
 import (
 	"context"

--- a/internal/pkg/metrics/common.go
+++ b/internal/pkg/metrics/common.go
@@ -1,0 +1,61 @@
+package mmmetrics
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	probe                       *AvailabilityProbe
+	controllerAvailabilityGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: "mintmaker",
+			Name:      "available",
+			Help:      "Number of scheduled MintMaker jobs",
+		})
+)
+
+func RegisterCommonMetrics(ctx context.Context, registerer prometheus.Registerer) error {
+	log := logr.FromContextOrDiscard(ctx)
+	if err := registerer.Register(controllerAvailabilityGauge); err != nil {
+		return fmt.Errorf("failed to register metrics: %w", err)
+	}
+	ticker := time.NewTicker(10 * time.Minute)
+	log.Info("Starting metrics")
+	go func() {
+		for {
+			select {
+			case <-ctx.Done(): // Shutdown if context is canceled
+				log.Info("Shutting down metrics")
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				checkProbes(ctx)
+			}
+		}
+	}()
+	return nil
+}
+
+func checkProbes(ctx context.Context) {
+	// Set availability metric based on contoller events (scheduled PipelineRuns)
+	events := (*probe).CheckEvents(ctx)
+	controllerAvailabilityGauge.Set(events)
+}
+
+func CountScheduledRuns() {
+	if probe == nil {
+		watcher := NewBackendProbe()
+		probe = &watcher
+	}
+	(*probe).AddEvent()
+}
+
+type AvailabilityProbe interface {
+	CheckEvents(ctx context.Context) float64
+	AddEvent()
+}

--- a/internal/pkg/metrics/common.go
+++ b/internal/pkg/metrics/common.go
@@ -1,4 +1,4 @@
-package mmmetrics
+package mintmakermetrics
 
 import (
 	"context"


### PR DESCRIPTION
Export availability metric through port 8443, as part of [kubebuilder](https://book.kubebuilder.io/reference/metrics.html) metrics. The availability metric tracks number of scheduled pipelineRuns. The prometheus recording will then track if a cluster has scheduled no pipelinerun in given time.