### PR TITLE
Enable prometheus SM

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -63,7 +63,7 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metrics endpoint binds to. "+
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,4 +1,4 @@
 # This patch adds the args to allow exposing the metrics endpoint using HTTPS
 - op: add
   path: /spec/template/spec/containers/0/args/0
-  value: --metrics-bind-address=:8443
+  value: --metrics-bind-address=:8080

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: mintmaker
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
-  namespace: system
+  namespace: mintmaker
 spec:
   ports:
   - name: http-metrics

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,14 +5,13 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: mintmaker
     app.kubernetes.io/managed-by: kustomize
-    openshift.io/cluster-monitoring: "true"
-  name: system
+  name: mintmaker
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
-  namespace: system
+  namespace: mintmaker
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: mintmaker
@@ -71,8 +70,8 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --metrics-bind-address=:8080
           - --metrics-secure=false
+          - --metrics-bind-address=:8080
         image: controller:latest
         name: manager
         env:

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 #    version: v1
 #    kind: Deployment
 #    name: controller-manager
-#    namespace: system
+#    namespace: mintmaker
 #  patch: |-
 #    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
 #    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.

--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: mintmaker
     app.kubernetes.io/managed-by: kustomize
   name: allow-metrics-traffic
-  namespace: system
+  namespace: mintmaker
 spec:
   podSelector:
     matchLabels:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -7,12 +7,12 @@ metadata:
     app.kubernetes.io/name: mintmaker
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
-  namespace: system
+  namespace: mintmaker
 spec:
   endpoints:
     - path: /metrics
-      port: https # Ensure this is the name of the port that exposes HTTPS metrics
-      scheme: https
+      port: http-metrics # Ensure this is the name of the port that exposes HTTPS metrics
+      scheme: http
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         # TODO(user): The option insecureSkipVerify: true is not recommended for production since it disables

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system
+  namespace: mintmaker

--- a/config/rbac/metrics_auth_role_binding.yaml
+++ b/config/rbac/metrics_auth_role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system
+  namespace: mintmaker

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -107,7 +107,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: manager-role
-  namespace: system
+  namespace: mintmaker
 rules:
 - apiGroups:
   - batch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -12,13 +12,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system
+  namespace: mintmaker
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: manager-rolebinding
-  namespace: system
+  namespace: mintmaker
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -5,4 +5,4 @@ metadata:
     app.kubernetes.io/name: mintmaker
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
-  namespace: system
+  namespace: mintmaker


### PR DESCRIPTION
The final changes to enable metric export via http which I tested on the local cluster. Should be merged together with https://github.com/redhat-appstudio/infra-deployments/pull/6296