### PR TITLE
Activate repo cache

### DIFF
--- a/internal/pkg/tekton/pipeline_run_builder.go
+++ b/internal/pkg/tekton/pipeline_run_builder.go
@@ -221,6 +221,14 @@ func NewPipelineRunBuilder(name, namespace string) *PipelineRunBuilder {
 													Name:  "RENOVATE_REDIS_URL",
 													Value: "redis://redis:6379",
 												},
+												{
+													Name:  "RENOVATE_REPOSITORY_CACHE",
+													Value: "enabled",
+												},
+												{
+													Name:  "RENOVATE_REPOSITORY_CACHE_TYPE",
+													Value: "redis://redis:6379/1",
+												},
 											},
 										},
 									},


### PR DESCRIPTION
The "1" at the end of redis URL denotes a different logical database, so that package and repository caches would be separated.