### PR TITLE
Revert "Run migration tool in update executionMode"

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -113,7 +113,7 @@
       "commands": [
         "pipeline-migration-tool -u '[{{#each upgrades}}{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"currentDigest\": \"{{{currentDigest}}}\", \"newValue\": \"{{{newValue}}}\", \"newDigest\": \"{{{newDigest}}}\", \"packageFile\": \"{{{packageFile}}}\", \"parentDir\": \"{{{parentDir}}}\", \"depTypes\": [{{#each depTypes}}\"{{{this}}}\"{{#unless @last}},{{\/unless}}{{\/each}}]}{{#unless @last}},{{\/unless}}{{\/each}}]'"
       ],
-      "executionMode": "update"
+      "executionMode": "branch"
     }
   },
   "dockerfile": {


### PR DESCRIPTION
Reverts konflux-ci/mintmaker#273

Unfortunately this doesn't work. The command is indeed called once for each update, but the command line is still the same, so now we just get many spawn E2BIG instead of one, thus making the problem worse. @tkdchen @qixiang @querti 
