### PR TITLE
Run migration tool in update executionMode (rework)

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -111,9 +111,9 @@
     ],
     "postUpgradeTasks": {
       "commands": [
-        "pipeline-migration-tool -u '[{{#each upgrades}}{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"currentDigest\": \"{{{currentDigest}}}\", \"newValue\": \"{{{newValue}}}\", \"newDigest\": \"{{{newDigest}}}\", \"packageFile\": \"{{{packageFile}}}\", \"parentDir\": \"{{{parentDir}}}\", \"depTypes\": [{{#each depTypes}}\"{{{this}}}\"{{#unless @last}},{{\/unless}}{{\/each}}]}{{#unless @last}},{{\/unless}}{{\/each}}]'"
+        "pipeline-migration-tool -u '[{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"currentDigest\": \"{{{currentDigest}}}\", \"newValue\": \"{{{newValue}}}\", \"newDigest\": \"{{{newDigest}}}\", \"packageFile\": \"{{{packageFile}}}\", \"parentDir\": \"{{{parentDir}}}\", \"depTypes\": [{{#each depTypes}}\"{{{this}}}\"{{#unless @last}},{{\/unless}}{{\/each}}]}]'"
       ],
-      "executionMode": "branch"
+      "executionMode": "update"
     }
   },
   "dockerfile": {
@@ -392,7 +392,7 @@
   "forkProcessing": "enabled",
   "allowedCommands": [
     "^rpm-lockfile-prototype rpms.in.yaml$",
-    "^pipeline-migration-tool -u '\\[\\{\\{#each upgrades\\}\\}\\{\"depName\": \"\\{\\{\\{depName\\}\\}\\}\", \"currentValue\": \"\\{\\{\\{currentValue\\}\\}\\}\", \"currentDigest\": \"\\{\\{\\{currentDigest\\}\\}\\}\", \"newValue\": \"\\{\\{\\{newValue\\}\\}\\}\", \"newDigest\": \"\\{\\{\\{newDigest\\}\\}\\}\", \"packageFile\": \"\\{\\{\\{packageFile\\}\\}\\}\", \"parentDir\": \"\\{\\{\\{parentDir\\}\\}\\}\", \"depTypes\": \\[\\{\\{#each depTypes\\}\\}\"\\{\\{\\{this\\}\\}\\}\"\\{\\{#unless @last\\}\\},\\{\\{\\/unless\\}\\}\\{\\{\\/each\\}\\}\\]\\}\\{\\{#unless @last\\}\\},\\{\\{\\/unless\\}\\}\\{\\{\\/each\\}\\}\\]'$"
+    "^pipeline-migration-tool -u '\\[\\{\"depName\": \"\\{\\{\\{depName\\}\\}\\}\", \"currentValue\": \"\\{\\{\\{currentValue\\}\\}\\}\", \"currentDigest\": \"\\{\\{\\{currentDigest\\}\\}\\}\", \"newValue\": \"\\{\\{\\{newValue\\}\\}\\}\", \"newDigest\": \"\\{\\{\\{newDigest\\}\\}\\}\", \"packageFile\": \"\\{\\{\\{packageFile\\}\\}\\}\", \"parentDir\": \"\\{\\{\\{parentDir\\}\\}\\}\", \"depTypes\": \\[\\{\\{#each depTypes\\}\\}\"\\{\\{\\{this\\}\\}\\}\"\\{\\{#unless @last\\}\\},\\{\\{\\/unless\\}\\}\\{\\{\\/each\\}\\}\\]\\}\\]'$"
   ],
   "updateNotScheduled": false,
   "dependencyDashboard": false,


### PR DESCRIPTION
KONFLUX-7886

This is a workaround for the story. The pipeline-migration-tool command line will be short enough with a single Renovate upgrade. However, the downside is that the migration tool will need to be run as many times as the total number of dependency updates, which may slow down the whole Renovate run for a Component repository.