### PR TITLE
fix: normalize repository label to comply with k8s conventions

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -258,7 +258,7 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(name string, comp co
 			"mintmaker.appstudio.redhat.com/namespace":    comp.GetNamespace(),
 			"mintmaker.appstudio.redhat.com/git-platform": comp.GetPlatform(), // (github, gitlab)
 			"mintmaker.appstudio.redhat.com/git-host":     comp.GetHost(),     // github.com, gitlab.com, gitlab.other.com
-			"mintmaker.appstudio.redhat.com/repository":   comp.GetRepository(),
+			"mintmaker.appstudio.redhat.com/repository":   utils.NormalizeLabelValue(comp.GetRepository()),
 		}).
 		WithTimeouts(nil)
 	builder.WithServiceAccount("mintmaker-controller-manager")

--- a/internal/pkg/utils/sanitize.go
+++ b/internal/pkg/utils/sanitize.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+// SanitizeLabelValue sanitizes a string to be valid for Kubernetes label values.
+// It handles common restrictions like maximum length (63 chars) and disallowed characters.
+func NormalizeLabelValue(value string) string {
+	// A valid label must be an empty string or consist of alphanumeric
+	// characters, '-', '_' or '.', and must start and end with an
+	// alphanumeric character
+
+	// Replace forward slashes with underscores (they're not allowed)
+	sanitized := strings.ReplaceAll(value, "/", "_")
+
+	// Ensure the length is within limits of 63
+	if len(sanitized) > 63 {
+		sanitized = sanitized[:63]
+	}
+
+	// Strip leading non-alphanumeric characters
+	sanitized = regexp.MustCompile(`^[^A-Za-z0-9]+`).ReplaceAllString(sanitized, "")
+
+	// Strip trailing non-alphanumeric characters
+	sanitized = regexp.MustCompile(`[^A-Za-z0-9]+$`).ReplaceAllString(sanitized, "")
+
+	// Further validation to ensure the sanitized string follows the exact pattern
+	// This would replace any sequences of invalid characters in the middle with a underscore
+	sanitized = regexp.MustCompile(`[^A-Za-z0-9_.-]+`).ReplaceAllString(sanitized, "_")
+
+	return sanitized
+}

--- a/internal/pkg/utils/sanitize_test.go
+++ b/internal/pkg/utils/sanitize_test.go
@@ -1,0 +1,149 @@
+// Copyright 2025 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestNormalizeLabelValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		description string
+	}{
+		{
+			name:        "Basic repository path",
+			input:       "owner/repo-name",
+			expected:    "owner_repo-name",
+			description: "Should replace slashes with hyphens",
+		},
+		{
+			name:        "With underscores",
+			input:       "owner_name/repo_name",
+			expected:    "owner_name_repo_name",
+			description: "Should keep underscores but replace slashes",
+		},
+		{
+			name:        "With dots",
+			input:       "owner.name/repo.name",
+			expected:    "owner.name_repo.name",
+			description: "Should keep dots but replace slashes",
+		},
+		{
+			name:        "With special characters",
+			input:       "owner$name/repo@name",
+			expected:    "owner_name_repo_name",
+			description: "Should remove invalid special characters",
+		},
+		{
+			name:        "Leading special characters",
+			input:       "-_./owner/repo",
+			expected:    "owner_repo",
+			description: "Should strip leading non-alphanumeric characters",
+		},
+		{
+			name:        "Trailing special characters",
+			input:       "owner/repo-_./",
+			expected:    "owner_repo",
+			description: "Should strip trailing non-alphanumeric characters",
+		},
+		{
+			name:        "Too long",
+			input:       "very-long-owner-name/extremely-long-repository-name-that-exceeds-the-maximum-length-for-kubernetes",
+			expected:    "very-long-owner-name_extremely-long-repository-name-that-exceed",
+			description: "Should truncate to max length of 63",
+		},
+		{
+			name:        "Empty string",
+			input:       "",
+			expected:    "",
+			description: "Should keep empty strings",
+		},
+		{
+			name:        "Only special characters",
+			input:       "-_./&^%$#@!",
+			expected:    "",
+			description: "Should use default when no valid characters remain",
+		},
+		{
+			name:        "Mixed valid and invalid",
+			input:       "valid-123_name.example/with&invalid^chars",
+			expected:    "valid-123_name.example_with_invalid_chars",
+			description: "Should preserve valid characters and replace invalid ones",
+		},
+		{
+			name:        "With consecutive invalid characters",
+			input:       "name-with!!!multiple@@@invalid###chars",
+			expected:    "name-with_multiple_invalid_chars",
+			description: "Should replace sequences of invalid chars with single hyphen",
+		},
+		{
+			name:        "With exactly 63 characters",
+			input:       "exactly-sixty-three-chars-long-label-value-for-kubernetes-label",
+			expected:    "exactly-sixty-three-chars-long-label-value-for-kubernetes-label",
+			description: "Should keep string unchanged if exactly at max length",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := NormalizeLabelValue(tc.input)
+			if result != tc.expected {
+				t.Errorf("NormalizeLabelValue(%q) = %q, expected %q\n%s",
+					tc.input, result, tc.expected, tc.description)
+			}
+
+			// Additional validation: check that result adheres to Kubernetes label value format
+			if !isValidKubernetesLabelValue(result) {
+				t.Errorf("Result %q is not a valid Kubernetes label value", result)
+			}
+
+		})
+	}
+}
+
+// Helper function to validate a Kubernetes label value based on the regex:
+// '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'
+func isValidKubernetesLabelValue(value string) bool {
+	// Empty string is valid
+	if value == "" {
+		return true
+	}
+
+	// Must start with alphanumeric
+	if len(value) > 0 && !isAlphanumeric(rune(value[0])) {
+		return false
+	}
+
+	// Must end with alphanumeric
+	if len(value) > 0 && !isAlphanumeric(rune(value[len(value)-1])) {
+		return false
+	}
+
+	// Middle characters must be alphanumeric, '-', '_', or '.'
+	for _, r := range value[1 : len(value)-1] {
+		if !isAlphanumeric(r) && r != '-' && r != '_' && r != '.' {
+			return false
+		}
+	}
+
+	return len(value) <= 63
+}
+
+func isAlphanumeric(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}


### PR DESCRIPTION
The repository path often contains disallowed char '/', and can exceed the maximum length (63) for k8s labels. This ensures all repository paths are valid as k8s label values.