### PR TITLE
Fix duplicate RPM PRs

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -162,6 +162,7 @@
         "matchManagers": [
           "rpm"
         ],
+        "separateMajorMinor": false,
         "recreateWhen": "always",
         "rebaseWhen": "behind-base-branch"
       }


### PR DESCRIPTION
For some reason (couldn't find why in the code) after the upgrade from `39.158.0` to `39.264.0` the behavior changed for RPM grouped updates. Setting `separateMajorMinor` to `false` (default is `true`) ensures that the PRs are not split into major and the rest.