### PR TITLE
Disable leader election

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -68,7 +68,6 @@ spec:
       - command:
         - /manager
         args:
-          - --leader-elect
           - --health-probe-bind-address=:8081
           - --metrics-secure=false
           - --metrics-bind-address=:8080


### PR DESCRIPTION
We have only one replica of the controller manager, and operations rarely cause conflicts (such as during deployment updates), making leader election unnecessary. Due to cluster performance issues, leader election was causing timeouts during leader lease renewal, which triggered controller restarts. Therefore, setting leader election to the default value of false to prevent these disruptions.