### PR TITLE
Revert "Migrate fileMatch to managerFilePatterns"

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -69,9 +69,9 @@
   ],
   "tekton": {
     "additionalBranchPrefix": "",
-    "managerFilePatterns": [
-      "/\\.yaml$/",
-      "/\\.yml$/"
+    "fileMatch": [
+      "\\.yaml$",
+      "\\.yml$"
     ],
     "includePaths": [
       ".tekton/**"


### PR DESCRIPTION
Reverts konflux-ci/mintmaker#293

This change is necessary when bumping renovate to a new version. However, we are currently blocked from doing that because it will break the use of pipeline-migration-tool. Revert this change so that the config is compatible with the older version of renovate.