### PR TITLE
fix: prevent panic on Component CRs with empty source

### DIFF
--- a/internal/pkg/component/component.go
+++ b/internal/pkg/component/component.go
@@ -44,7 +44,10 @@ type GitComponent interface {
 }
 
 func NewGitComponent(comp *appstudiov1alpha1.Component, client client.Client, ctx context.Context) (GitComponent, error) {
-	// TODO: validate git URL
+    // First check if source url exists and is properly defined
+    if comp.Spec.Source.GitSource == nil || comp.Spec.Source.GitSource.URL == "" {
+        return nil, fmt.Errorf("component %s has no git source or empty URL defined", comp.Name)
+    }
 	platform, err := utils.GetGitPlatform(comp.Spec.Source.GitSource.URL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When processing Component CRs, the controller would panic if the spec.source field was nil, which occurs with Components created without git source information.

JIRA: CWFHEALTH-4314