### PR TITLE
Introduce a new event reconciler to generate tokens on-demand

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+
 	mmv1alpha1 "github.com/konflux-ci/mintmaker/api/v1alpha1"
 	"github.com/konflux-ci/mintmaker/internal/controller"
 	mintmakermetrics "github.com/konflux-ci/mintmaker/internal/pkg/metrics"
@@ -161,6 +162,14 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PipelineRun")
+		os.Exit(1)
+	}
+
+	if err = (&controller.EventReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Event")
 		os.Exit(1)
 	}
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,7 +68,11 @@ rules:
   - events
   verbs:
   - create
+  - get
+  - list
   - patch
+  - update
+  - watch
 - apiGroups:
   - tekton.dev
   resources:

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.21.1 // indirect
+	github.com/prometheus/client_golang v1.21.1
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect

--- a/internal/controller/event_controller.go
+++ b/internal/controller/event_controller.go
@@ -1,0 +1,224 @@
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"regexp"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+
+	component "github.com/konflux-ci/mintmaker/internal/pkg/component"
+	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
+)
+
+// EventReconciler reconciles a Event object
+type EventReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// markEventAsProcessed adds an annotation to the event indicating it has been processed
+func (r *EventReconciler) markEventAsProcessed(ctx context.Context, event *corev1.Event) error {
+	patchEvent := event.DeepCopy()
+
+	if patchEvent.Annotations == nil {
+		patchEvent.Annotations = make(map[string]string)
+	}
+
+	original := patchEvent.DeepCopy()
+	patchEvent.Annotations["mintmaker.appstudio.redhat.com/processed"] = "true"
+
+	patch := client.MergeFrom(original)
+
+	if err := r.Patch(ctx, patchEvent, patch); err != nil {
+		return err
+	}
+	return nil
+}
+
+// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=events/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=events/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Event object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.0/pkg/reconcile
+func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx).WithName("EventController")
+	ctx = ctrllog.IntoContext(ctx, log)
+
+	var evt corev1.Event
+	if err := r.Get(ctx, req.NamespacedName, &evt); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Check that the involved object is a Pod
+	if evt.InvolvedObject.Kind != "Pod" {
+		return ctrl.Result{}, nil
+	}
+
+	// Extract volume name from the event message
+	// When the event is triggered by missing Renovate token, the message is in this format:
+	// MountVolume.SetUp failed for volume "secret-renovate-07110345-e8d4c7bf" : references non-existent secret key: renovate-token
+	msgRegex := regexp.MustCompile(`volume "([^"]+)".*references non-existent secret key: renovate-token`)
+	matches := msgRegex.FindStringSubmatch(evt.Message)
+
+	if len(matches) < 2 {
+		// This is not an event we're monitoring
+		if err := r.markEventAsProcessed(ctx, &evt); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+	volumeName := matches[1]
+
+	// Get the pod details from the involved object
+	podName := evt.InvolvedObject.Name
+	podNamespace := evt.InvolvedObject.Namespace
+
+	// Get the actual corresponding Pod object for this event
+	var pod corev1.Pod
+	if err := r.Get(ctx, client.ObjectKey{Namespace: podNamespace, Name: podName}, &pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			// This is an event related to an old Pod which doesn't exist anymore
+			if err := r.markEventAsProcessed(ctx, &evt); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Find the corresponding secret
+	var secretName string
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Name == volumeName && volume.Secret != nil {
+			secretName = volume.Secret.SecretName
+			break
+		}
+	}
+	if secretName == "" {
+		// Volume doesn't have a corresponding secret, ignore it
+		if err := r.markEventAsProcessed(ctx, &evt); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Get the secret
+	var secret corev1.Secret
+	if err := r.Get(ctx, client.ObjectKey{Namespace: podNamespace, Name: secretName}, &secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Secret doesn't exist, in theory this should not happen unless someone
+			// deleted the secret by manual, anyway we will ignore this
+			if err := r.markEventAsProcessed(ctx, &evt); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Add the missing `renovate-token` key
+	if _, hasKey := secret.Data["renovate-token"]; !hasKey {
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
+
+		componentName := pod.Labels[MintMakerComponentNameLabel]
+		componentNamespace := pod.Labels[MintMakerComponentNamespaceLabel]
+
+		// Get the component
+		var comp appstudiov1alpha1.Component
+		if err := r.Get(ctx, client.ObjectKey{Namespace: componentNamespace, Name: componentName}, &comp); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Create GitComponent from Component
+		gitComp, err := component.NewGitComponent(&comp, r.Client, ctx)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// When this is a GitHub component, it also refreshes token if needed
+		token, err := gitComp.GetToken()
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Add the missing Renovate token
+		log.Info("updating renovate token in secret", "secret", secretName)
+		secret.Data["renovate-token"] = []byte(token)
+
+		// Update the secret
+		if err := r.Update(ctx, &secret); err != nil {
+			log.Error(err, "failed to update renovate token in secret", secret, secretName)
+			return ctrl.Result{}, err
+		}
+	}
+
+	if err := r.markEventAsProcessed(ctx, &evt); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *EventReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Event{}).
+		WithEventFilter(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				if e.Object.GetNamespace() != MintMakerNamespaceName {
+					return false
+				}
+				evt, ok := e.Object.(*corev1.Event)
+				if !ok {
+					return false
+				}
+				if evt.Reason != "FailedMount" {
+					return false
+				}
+				if _, exists := evt.Annotations["mintmaker.appstudio.redhat.com/processed"]; exists {
+					return false
+				}
+				return true
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				return false
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return false
+			},
+			GenericFunc: func(e event.GenericEvent) bool {
+				return false
+			},
+		}).
+		Complete(r)
+}

--- a/internal/controller/event_controller_test.go
+++ b/internal/controller/event_controller_test.go
@@ -1,0 +1,296 @@
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ghcomponent "github.com/konflux-ci/mintmaker/internal/pkg/component/github"
+	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
+)
+
+var _ = Describe("Event Controller", func() {
+
+	var (
+		origGetTokenFn func() (string, error)
+	)
+
+	Context("When reconciling an event", func() {
+		const (
+			componentName      = "test-component"
+			componentNamespace = "test-namespace"
+			podName            = "test-pod"
+			secretName         = "test-secret"
+			volumeName         = "test-volume"
+		)
+
+		var (
+			pod    *corev1.Pod
+			secret *corev1.Secret
+		)
+
+		BeforeEach(func() {
+			origGetTokenFn = ghcomponent.GetTokenFn
+			ghcomponent.GetTokenFn = func() (string, error) {
+				return "fake-token", nil
+			}
+
+			createNamespace(MintMakerNamespaceName)
+			createNamespace(componentNamespace)
+
+			// Create the pipelines-as-code-secret
+			pacSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pipelines-as-code-secret",
+					Namespace: MintMakerNamespaceName,
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("12345"),
+					"github-private-key":    []byte(testPrivateKey),
+				},
+			}
+			Expect(k8sClient.Create(ctx, pacSecret)).Should(Succeed())
+
+			componentKey := types.NamespacedName{Name: componentName, Namespace: componentNamespace}
+			createComponent(
+				componentKey, "app", "https://github.com/testcomp.git", "gitrevision", "gitsourcecontext",
+			)
+
+			pod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: MintMakerNamespaceName,
+					Labels: map[string]string{
+						MintMakerComponentNameLabel:      componentName,
+						MintMakerComponentNamespaceLabel: componentNamespace,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test", Image: "test"}},
+					Volumes: []corev1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: secretName,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: MintMakerNamespaceName,
+				},
+				Data: map[string][]byte{},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			ghcomponent.GetTokenFn = origGetTokenFn
+			deleteEvents(MintMakerNamespaceName)
+			Expect(k8sClient.Delete(ctx, pod)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, secret)).Should(Succeed())
+			deleteComponent(types.NamespacedName{Name: componentName, Namespace: componentNamespace})
+			deleteSecret(types.NamespacedName{Name: "pipelines-as-code-secret", Namespace: MintMakerNamespaceName})
+		})
+
+		It("should successfully add the renovate token", func() {
+			event := &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-event",
+					Namespace: MintMakerNamespaceName,
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Kind:      "Pod",
+					Name:      podName,
+					Namespace: MintMakerNamespaceName,
+				},
+				Reason:  "FailedMount",
+				Message: `MountVolume.SetUp failed for volume "` + volumeName + `" : references non-existent secret key: renovate-token`,
+			}
+			Expect(k8sClient.Create(ctx, event)).Should(Succeed())
+
+			Eventually(func() (string, error) {
+				updatedSecret := &corev1.Secret{}
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: secretName, Namespace: MintMakerNamespaceName}, updatedSecret); err != nil {
+					return "", err
+				}
+				return string(updatedSecret.Data["renovate-token"]), nil
+			}, time.Second*10).Should(Equal("fake-token"))
+		})
+
+		It("should ignore event for non-pod object", func() {
+			event := &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-event-non-pod",
+					Namespace: MintMakerNamespaceName,
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Kind:      "Deployment",
+					Name:      "some-deployment",
+					Namespace: MintMakerNamespaceName,
+				},
+				Reason:  "FailedMount",
+				Message: "some message",
+			}
+			Expect(k8sClient.Create(ctx, event)).Should(Succeed())
+			Consistently(func() map[string][]byte {
+				updatedSecret := &corev1.Secret{}
+				_ = k8sClient.Get(ctx, client.ObjectKey{Name: secretName, Namespace: MintMakerNamespaceName}, updatedSecret)
+				return updatedSecret.Data
+			}).ShouldNot(HaveKey("renovate-token"))
+		})
+
+		It("should ignore event with non-matching message", func() {
+			event := &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-event-bad-msg",
+					Namespace: MintMakerNamespaceName,
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Kind:      "Pod",
+					Name:      podName,
+					Namespace: MintMakerNamespaceName,
+				},
+				Reason:  "FailedMount",
+				Message: "another error message",
+			}
+			Expect(k8sClient.Create(ctx, event)).Should(Succeed())
+			Consistently(func() map[string][]byte {
+				updatedSecret := &corev1.Secret{}
+				_ = k8sClient.Get(ctx, client.ObjectKey{Name: secretName, Namespace: MintMakerNamespaceName}, updatedSecret)
+				return updatedSecret.Data
+			}).ShouldNot(HaveKey("renovate-token"))
+		})
+
+		It("should ignore event for a pod that no longer exists", func() {
+			event := &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-event-deleted-pod",
+					Namespace: MintMakerNamespaceName,
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Kind:      "Pod",
+					Name:      "deleted-pod",
+					Namespace: MintMakerNamespaceName,
+				},
+				Reason:  "FailedMount",
+				Message: `MountVolume.SetUp failed for volume "` + volumeName + `" : references non-existent secret key: renovate-token`,
+			}
+			Expect(k8sClient.Create(ctx, event)).Should(Succeed())
+			Consistently(func() map[string][]byte {
+				updatedSecret := &corev1.Secret{}
+				_ = k8sClient.Get(ctx, client.ObjectKey{Name: secretName, Namespace: MintMakerNamespaceName}, updatedSecret)
+				return updatedSecret.Data
+			}).ShouldNot(HaveKey("renovate-token"))
+		})
+
+		It("should ignore event for a pod where the volume does not have a corresponding secret", func() {
+			podWithoutSecretVolume := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-no-secret-volume",
+					Namespace: MintMakerNamespaceName,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test", Image: "test"}},
+					Volumes: []corev1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "some-configmap",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, podWithoutSecretVolume)).Should(Succeed())
+
+			event := &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-event-no-secret-volume",
+					Namespace: MintMakerNamespaceName,
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Kind:      "Pod",
+					Name:      podWithoutSecretVolume.Name,
+					Namespace: MintMakerNamespaceName,
+				},
+				Reason:  "FailedMount",
+				Message: `MountVolume.SetUp failed for volume "` + volumeName + `" : references non-existent secret key: renovate-token`,
+			}
+			Expect(k8sClient.Create(ctx, event)).Should(Succeed())
+			Consistently(func() map[string][]byte {
+				updatedSecret := &corev1.Secret{}
+				_ = k8sClient.Get(ctx, client.ObjectKey{Name: secretName, Namespace: MintMakerNamespaceName}, updatedSecret)
+				return updatedSecret.Data
+			}).ShouldNot(HaveKey("renovate-token"))
+
+			Expect(k8sClient.Delete(ctx, podWithoutSecretVolume)).Should(Succeed())
+		})
+
+		It("should ignore an event that has already been processed", func() {
+			event := &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-event-processed",
+					Namespace: MintMakerNamespaceName,
+					Annotations: map[string]string{
+						"mintmaker.appstudio.redhat.com/processed": "true",
+					},
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Kind:      "Pod",
+					Name:      podName,
+					Namespace: MintMakerNamespaceName,
+				},
+				Reason:  "FailedMount",
+				Message: `MountVolume.SetUp failed for volume "` + volumeName + `" : references non-existent secret key: renovate-token`,
+			}
+			Expect(k8sClient.Create(ctx, event)).Should(Succeed())
+
+			Consistently(func() map[string][]byte {
+				updatedSecret := &corev1.Secret{}
+				_ = k8sClient.Get(ctx, client.ObjectKey{Name: secretName, Namespace: MintMakerNamespaceName}, updatedSecret)
+				return updatedSecret.Data
+			}).ShouldNot(HaveKey("renovate-token"))
+		})
+	})
+})
+
+func deleteEvents(namespace string) {
+	eventList := &corev1.EventList{}
+	err := k8sClient.List(ctx, eventList, client.InNamespace(namespace))
+	Expect(err).NotTo(HaveOccurred())
+	for _, event := range eventList.Items {
+		err := k8sClient.Delete(ctx, &event)
+		Expect(err).NotTo(HaveOccurred())
+	}
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -37,6 +37,11 @@ import (
 	mmv1alpha1 "github.com/konflux-ci/mintmaker/api/v1alpha1"
 )
 
+const (
+	timeout  = time.Second * 2
+	interval = time.Millisecond * 250
+)
+
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
@@ -100,6 +105,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&PipelineRunReconciler{Client: k8sManager.GetClient(), Scheme: k8sManager.GetScheme()}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&EventReconciler{Client: k8sManager.GetClient(), Scheme: k8sManager.GetScheme()}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/internal/controller/suite_util_test.go
+++ b/internal/controller/suite_util_test.go
@@ -32,13 +32,6 @@ import (
 	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
 )
 
-const (
-	// timeout is used as a limit until condition become true
-	// Usually used in Eventually statements
-	timeout  = time.Second * 15
-	interval = time.Millisecond * 250
-)
-
 var testPrivateKey = "-----BEGIN PRIVATE KEY-----\n" +
 	"MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC0lZNSLqX1n2aO" +
 	"loffn3rBL2+3Mm/GnjkWVQz76TS3KO7RSf4Det017H80XUumx3fT26rZ+wgpN8fi" +


### PR DESCRIPTION
Previously, we generated Renovate tokens for components while creating the pipelineruns, then before starting the pipelineruns for GitHub components, we checked and refreshed the token to ensure it's valid for the pipelinerun execution.

However, a queue system will be added to Konflux, meaning when we start a pipelinerun, it may stay in the queue until the cluster is able to execute it. We can't predict when the pipelinerun will actually start, so refreshing the token before starting a pipelinerun can't ensure the token is still valid when the pipelinerun is actually executed.

In this change, we don't create the renovate token in secret while creating pipelineruns for GitHub components. Instead, we introduced a new event reconciler to monitor events. When a pipelinerun is started but the pod can't mount the renovate token (because we didn't create it), an event will be triggered, with a message like this:

    MountVolume.SetUp failed for volume "secret-renovate-07110345-e8d4c7bf"
    : references non-existent secret key: renovate-token

The pod will retry and wait until the secret key `renovate-token` is available. We will then generate the token and update the secret to make the pod able to start. This ensures the pod has a valid GitHub token when it's actually started.

JIRA: CWFHEALTH-4054