### PR TITLE
fix(rbac): grant controller pod list/get/watch permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,6 +41,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create


### PR DESCRIPTION
Add permissions for the controller service account to get, list, and watch pods. The new event controller requires these permissions.