### PR TITLE
Ensure that nonstandard tekton updates support multiple base branches

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -68,7 +68,6 @@
     "gitlabci-include"
   ],
   "tekton": {
-    "additionalBranchPrefix": "",
     "fileMatch": [
       "\\.yaml$",
       "\\.yml$"
@@ -85,6 +84,7 @@
         "enabled": true,
         "groupName": "Konflux references",
         "branchPrefix": "konflux/references/",
+        "additionalBranchPrefix": "",
         "group": {
           "branchTopic": "{{{baseBranch}}}",
           "commitMessageTopic": "{{{groupName}}}"


### PR DESCRIPTION
In the past, we have added "additionalBranchPrefix": "{{baseBranch}}/" configuration for all MintMaker updates so that multiple base branches would be supported. The only exception were tekton updates, which followed a different pattern for historical reasons. This tekton configuration works for images that match the package rule, but breaks for other images. The reason is that images not matching the package rule still have the setting "additionalBranchPrefix": "", even though they follow the standard branch naming pattern. This results in base branch being excluded from the renovate branch name, causing interference if multiple base branches are specified. The issue can be fixed by moving "additionalBranchPrefix" setting inside the package rule, so that non-matching tekton updates will include base branch in their branch name, as defined in the top-level config.

Standard tekton updates will not be affected by this change, but updates with non-matching package rules will have their old PRs become stale without automatic removal. This is due to '"pruneStaleBranches": false' being set. However, I think that the list of users affected by this change is so low, that we don't need to formally announce this.

Tests:
Standard tekton updates are unaffected: https://github.com/querti/renovate-tests/pull/211 https://github.com/querti/renovate-tests/pull/209
Non-standard tekton updates using different branch names: https://github.com/querti/renovate-tests/pull/213 https://github.com/querti/renovate-tests/pull/212
Old non-standard tekton update being left open after the change: https://github.com/querti/renovate-tests/pull/210

Jira: CLOUDDST-28412