### PR TITLE
Log pipelinerun cancellations

### DIFF
--- a/internal/controller/event_controller.go
+++ b/internal/controller/event_controller.go
@@ -109,6 +109,8 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			err := r.Patch(ctx, &plr, patch)
 			if err != nil {
 				log.Error(err, "unable to cancel pipelinerun", "pipelinerun", plr.Name)
+			} else {
+				log.Info("pipelinerun is cancelled", "pipelinerun", plr.Name, "reason", errMessage)
 			}
 		}
 	}()


### PR DESCRIPTION
This change adds an info-level log message when a pipelinerun is successfully cancelled, improving observability and making it easier to trace the pipelinerun history.