### PR TITLE
Migrate fileMatch to managerFilePatterns

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -68,9 +68,9 @@
     "gitlabci-include"
   ],
   "tekton": {
-    "fileMatch": [
-      "\\.yaml$",
-      "\\.yml$"
+    "managerFilePatterns": [
+      "/\\.yaml$/",
+      "/\\.yml$/"
     ],
     "includePaths": [
       ".tekton/**"


### PR DESCRIPTION
This is now ready for the new Renovate version, see #301 and #293 