### PR TITLE
Use user-provided image registry secrets

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -82,6 +82,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - tekton.dev
   resources:
   - pipelineruns

--- a/internal/controller/dependencyupdatecheck_controller_test.go
+++ b/internal/controller/dependencyupdatecheck_controller_test.go
@@ -15,6 +15,8 @@
 package controller
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -32,20 +34,28 @@ var _ = Describe("DependencyUpdateCheck Controller", func() {
 		origGetTokenFn        func() (string, error)
 	)
 
-	Context("Test Renovate jobs creation", func() {
+	Context("When reconciling a DependencyUpdateCheck CR", func() {
+
+		const (
+			dependencyUpdateCheckName = "dependencyupdatecheck-sample"
+			componentName             = "testcomp"
+			componentNamespace        = "testnamespace"
+		)
+
+		dependencyUpdateCheckKey := types.NamespacedName{Namespace: MintMakerNamespaceName, Name: dependencyUpdateCheckName}
 
 		_ = BeforeEach(func() {
 			createNamespace(MintMakerNamespaceName)
-			createNamespace("testnamespace")
+			createNamespace(componentNamespace)
 			createComponent(
-				types.NamespacedName{Name: "testcomp", Namespace: "testnamespace"}, "app", "https://github.com/testcomp.git", "gitrevision", "gitsourcecontext",
+				types.NamespacedName{Name: componentName, Namespace: componentNamespace}, "app", "https://github.com/testcomp.git", "gitrevision", "gitsourcecontext",
 			)
 			secretData := map[string]string{
 				"github-application-id": "1234567890",
 				"github-private-key":    testPrivateKey,
 			}
 			createSecret(
-				types.NamespacedName{Namespace: MintMakerNamespaceName, Name: "pipelines-as-code-secret"}, secretData,
+				types.NamespacedName{Namespace: MintMakerNamespaceName, Name: "pipelines-as-code-secret"}, corev1.SecretTypeOpaque, nil, secretData,
 			)
 			configMapData := map[string]string{"renovate.json": "{}"}
 			createConfigMap(types.NamespacedName{Namespace: MintMakerNamespaceName, Name: "renovate-config"}, configMapData)
@@ -65,34 +75,122 @@ var _ = Describe("DependencyUpdateCheck Controller", func() {
 
 		_ = AfterEach(func() {
 			deletePipelineRuns(MintMakerNamespaceName)
-			deleteComponent(types.NamespacedName{Name: "testcomp", Namespace: "testnamespace"})
+			deleteComponent(types.NamespacedName{Name: componentName, Namespace: componentNamespace})
 			deleteSecret(types.NamespacedName{Namespace: MintMakerNamespaceName, Name: "pipelines-as-code-secret"})
 			deleteConfigMap(types.NamespacedName{Namespace: MintMakerNamespaceName, Name: "renovate-config"})
 			ghcomponent.GetRenovateConfigFn = origGetRenovateConfig
 			ghcomponent.GetTokenFn = origGetTokenFn
 		})
 
-		It("should create a pipeline run when a CR DependencyUpdateCheck is created", func() {
-			dependencyUpdateCheckKey := types.NamespacedName{Namespace: MintMakerNamespaceName, Name: "dependencyupdatecheck-sample"}
+		It("should create a pipelinerun", func() {
 			createDependencyUpdateCheck(dependencyUpdateCheckKey, false, nil)
 			Eventually(listPipelineRuns).WithArguments(MintMakerNamespaceName).Should(HaveLen(1))
 			deleteDependencyUpdateCheck(dependencyUpdateCheckKey)
 		})
 
-		It("should not create a pipelinerun for DependencyUpdateCheck CR which has been processed before", func() {
+		It("should not create a pipelinerun if the DependencyUpdateCheck CR has been processed before", func() {
 			// Create a DependencyUpdateCheck CR in "mintmaker" namespace, that was processed before
-			dependencyUpdateCheckKey := types.NamespacedName{Namespace: MintMakerNamespaceName, Name: "dependencyupdatecheck-sample"}
 			createDependencyUpdateCheck(dependencyUpdateCheckKey, true, nil)
 			Eventually(listPipelineRuns).WithArguments(MintMakerNamespaceName).Should(HaveLen(0))
 			deleteDependencyUpdateCheck(dependencyUpdateCheckKey)
 		})
 
-		It("should not create a pipelinerun for DependencyUpdateCheck CR that is not from mintmaker namespace", func() {
-			// Create a DependencyUpdateCheck CR in "mintmaker" namespace, that was processed before
-			dependencyUpdateCheckKey := types.NamespacedName{Namespace: "default", Name: "dependencyupdatecheck-sample"}
-			createDependencyUpdateCheck(dependencyUpdateCheckKey, false, nil)
+		It("should not create a pipelinerun if the DependencyUpdateCheck CR is not from the mintmaker namespace", func() {
+			createDependencyUpdateCheck(types.NamespacedName{Namespace: "default", Name: dependencyUpdateCheckName}, false, nil)
 			Eventually(listPipelineRuns).WithArguments(MintMakerNamespaceName).Should(HaveLen(0))
-			deleteDependencyUpdateCheck(dependencyUpdateCheckKey)
+			deleteDependencyUpdateCheck(types.NamespacedName{Namespace: "default", Name: dependencyUpdateCheckName})
+		})
+
+		Context("When getting a merged docker config for a pipelinerun", func() {
+
+			const (
+				serviceAccountName = "build-pipeline-" + componentName
+				registrySecretName = "testregistrysecret"
+			)
+
+			var mergedConfigJson []byte
+			registrySecretKey := types.NamespacedName{Namespace: componentNamespace, Name: registrySecretName}
+			serviceAccountKey := types.NamespacedName{Namespace: componentNamespace, Name: serviceAccountName}
+
+			_ = BeforeEach(func() {
+				createServiceAccount(serviceAccountKey)
+
+				// Create a merged docker config
+				mergedAuths := map[string]interface{}{
+					"https://fake-registry.com": map[string]string{"auth": "fake-auth"},
+				}
+				var err error
+				mergedConfigJson, err = json.Marshal(map[string]interface{}{"auths": mergedAuths})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			_ = AfterEach(func() {
+				deleteServiceAccount(serviceAccountKey)
+			})
+
+			It("should include secrets linked to the build-pipeline service account", func() {
+				// Create image registry secret
+				secretData := map[string][]byte{corev1.DockerConfigJsonKey: mergedConfigJson}
+				createSecret(registrySecretKey, corev1.SecretTypeDockerConfigJson, secretData, nil)
+
+				// Link the registry secret to the service account
+				serviceAccount := getServiceAccount(serviceAccountKey)
+				serviceAccount.Secrets = []corev1.ObjectReference{{Name: registrySecretName}}
+				Expect(k8sClient.Update(ctx, serviceAccount)).Should(Succeed())
+
+				createDependencyUpdateCheck(dependencyUpdateCheckKey, false, nil)
+
+				Eventually(listPipelineRuns).WithArguments(MintMakerNamespaceName).Should(HaveLen(1))
+				Eventually(func() map[string][]byte {
+					plrName := listPipelineRuns(MintMakerNamespaceName)[0].Name
+					renovateSecret := getSecret(types.NamespacedName{Namespace: MintMakerNamespaceName, Name: plrName})
+					return renovateSecret.Data
+				}).Should(HaveKeyWithValue(corev1.DockerConfigJsonKey, mergedConfigJson))
+
+				deleteSecret(registrySecretKey)
+				deleteDependencyUpdateCheck(dependencyUpdateCheckKey)
+			})
+
+			It("should exclude secrets that are not linked to the build-pipeline service account", func() {
+				// Create image registry secret
+				secretData := map[string][]byte{corev1.DockerConfigJsonKey: mergedConfigJson}
+				createSecret(registrySecretKey, corev1.SecretTypeDockerConfigJson, secretData, nil)
+
+				createDependencyUpdateCheck(dependencyUpdateCheckKey, false, nil)
+
+				Eventually(listPipelineRuns).WithArguments(MintMakerNamespaceName).Should(HaveLen(1))
+				Consistently(func() map[string][]byte {
+					plrName := listPipelineRuns(MintMakerNamespaceName)[0].Name
+					renovateSecret := getSecret(types.NamespacedName{Namespace: MintMakerNamespaceName, Name: plrName})
+					return renovateSecret.Data
+				}).Should(BeNil())
+
+				deleteSecret(registrySecretKey)
+				deleteDependencyUpdateCheck(dependencyUpdateCheckKey)
+			})
+
+			It("should exclude secrets that do not contain a docker config", func() {
+				// Create image registry secret
+				secretData := map[string][]byte{corev1.BasicAuthUsernameKey: []byte("testusername"), corev1.BasicAuthPasswordKey: []byte("testpassword")}
+				createSecret(registrySecretKey, corev1.SecretTypeBasicAuth, secretData, nil)
+
+				// Link the registry secret to the service account
+				serviceAccount := getServiceAccount(serviceAccountKey)
+				serviceAccount.Secrets = []corev1.ObjectReference{{Name: registrySecretName}}
+				Expect(k8sClient.Update(ctx, serviceAccount)).Should(Succeed())
+
+				createDependencyUpdateCheck(dependencyUpdateCheckKey, false, nil)
+
+				Eventually(listPipelineRuns).WithArguments(MintMakerNamespaceName).Should(HaveLen(1))
+				Consistently(func() map[string][]byte {
+					plrName := listPipelineRuns(MintMakerNamespaceName)[0].Name
+					renovateSecret := getSecret(types.NamespacedName{Namespace: MintMakerNamespaceName, Name: plrName})
+					return renovateSecret.Data
+				}).Should(BeNil())
+
+				deleteSecret(registrySecretKey)
+				deleteDependencyUpdateCheck(dependencyUpdateCheckKey)
+			})
 		})
 	})
 })

--- a/internal/pkg/component/base/base.go
+++ b/internal/pkg/component/base/base.go
@@ -83,14 +83,14 @@ type HostRule map[string]string
 func (c *BaseComponent) TransformHostRules(ctx context.Context, registrySecret *corev1.Secret) ([]HostRule, error) {
 	log := logger.FromContext(ctx)
 
-	if registrySecret == nil {
-		return nil, errors.New("Registry secret is nil")
+	if _, exists := registrySecret.Data[corev1.DockerConfigJsonKey]; !exists {
+		return nil, errors.New(fmt.Sprintf("Secret %s is missing the %s key", registrySecret.Name, corev1.DockerConfigJsonKey))
 	}
 
 	var hostRules []HostRule
 	var secrets map[string]map[string]HostRule
 
-	err := json.Unmarshal(registrySecret.Data[".dockerconfigjson"], &secrets)
+	err := json.Unmarshal(registrySecret.Data[corev1.DockerConfigJsonKey], &secrets)
 
 	if err != nil {
 		log.Info(fmt.Sprintf("Cannot unmarshal registry secret: %s", err))

--- a/internal/pkg/component/component.go
+++ b/internal/pkg/component/component.go
@@ -44,10 +44,10 @@ type GitComponent interface {
 }
 
 func NewGitComponent(comp *appstudiov1alpha1.Component, client client.Client, ctx context.Context) (GitComponent, error) {
-    // First check if source url exists and is properly defined
-    if comp.Spec.Source.GitSource == nil || comp.Spec.Source.GitSource.URL == "" {
-        return nil, fmt.Errorf("component %s has no git source or empty URL defined", comp.Name)
-    }
+	// First check if source url exists and is properly defined
+	if comp.Spec.Source.GitSource == nil || comp.Spec.Source.GitSource.URL == "" {
+		return nil, fmt.Errorf("component %s has no git source or empty URL defined", comp.Name)
+	}
 	platform, err := utils.GetGitPlatform(comp.Spec.Source.GitSource.URL)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/tekton/pipeline_run_builder.go
+++ b/internal/pkg/tekton/pipeline_run_builder.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
+	"github.com/konflux-ci/mintmaker/internal/pkg/utils"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -342,7 +343,9 @@ func (b *PipelineRunBuilder) WithSecret(name, mountPath string, items []corev1.K
 	// Find the specified task
 	for i, task := range b.pipelineRun.Spec.PipelineSpec.Tasks {
 		if task.Name == opts.TaskName && task.TaskSpec != nil {
-			volumeName := fmt.Sprintf("secret-%s", name)
+			// Generate unique volume name using random string to avoid conflicts
+			// when the same secret is mounted multiple times
+			volumeName := fmt.Sprintf("secret-%s-%s", name, utils.RandomString(8))
 			volume := corev1.Volume{
 				Name: volumeName,
 				VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
Previously, MintMaker used global pull secrets for registry.redhat.io and registry.stage.redhat.io. These secrets were applied to all PipelineRuns, regardless of need. This approach created a security issue by allowing any user to access these secure registries, even without proper permissions.

This commit updates the DependencyUpdateCheck controller to use user-provided image registry secrets instead. For images onboarded to Konflux, these secrets are expected to be provided and linked to a component-specific service account in the user namespace called build-pipeline-$COMPONENT_NAME.

JIRA: CWFHEALTH-4113