### PR TITLE
Temporarily disable tekton manager

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -23,7 +23,6 @@
   "additionalBranchPrefix": "{{baseBranch}}/",
   "branchPrefix": "konflux/mintmaker/",
   "enabledManagers": [
-    "tekton",
     "dockerfile",
     "rpm",
     "custom.regex",


### PR DESCRIPTION
Skip the upcoming Saturday run since the pipeline-migration-tool seems to be broken. This change should be reverted at a later date.