### PR TITLE
Remove pending status and concurrent limit for PipelineRuns

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -491,7 +491,7 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 			processedComponents = append(processedComponents, key)
 		}
 
-		log.Info(fmt.Sprintf("creating pending PipelineRun for %s", key))
+		log.Info(fmt.Sprintf("creating PipelineRun for %s", key))
 		plrName := fmt.Sprintf("renovate-%s-%s", timestamp, utils.RandomString(8))
 		pipelinerun, err := r.createPipelineRun(plrName, comp, ctx, registrySecret)
 		if err != nil {

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -17,7 +17,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,14 +24,12 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
 	"github.com/konflux-ci/mintmaker/internal/pkg/config"
 	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
-	mintmakermetrics "github.com/konflux-ci/mintmaker/internal/pkg/metrics"
 )
 
 var (
@@ -48,96 +45,7 @@ type PipelineRunReconciler struct {
 	Config *config.ControllerConfig
 }
 
-// updatePipelineRunState updates the status of a PipelineRun
-func (r *PipelineRunReconciler) updatePipelineRunState(
-	ctx context.Context,
-	pipelineRun tektonv1.PipelineRun,
-	status tektonv1.PipelineRunSpecStatus,
-	errmsg string,
-) error {
-	log := ctrllog.FromContext(ctx)
-	originalPipelineRun := pipelineRun.DeepCopy()
-	pipelineRun.Spec.Status = status
-
-	// If pipelinerun is to be cancelled, add reason with the error message
-	if status == tektonv1.PipelineRunSpecStatusCancelled {
-		pipelineRun.Status.MarkFailed(string(tektonv1.PipelineRunReasonCancelled), "%s", errmsg)
-	}
-
-	patch := client.MergeFrom(originalPipelineRun)
-	if err := r.Client.Patch(ctx, &pipelineRun, patch); err != nil {
-		log.Error(err, "unable to update pipelinerun status", "pipelinerun", pipelineRun.Name)
-		return err
-	}
-	return nil
-}
-
-// startPipelineRun starts a pending PipelineRun by removing its pending status
-// Returns true if successfully started, false otherwise
-func (r *PipelineRunReconciler) startPipelineRun(ctx context.Context, plr tektonv1.PipelineRun) bool {
-	log := ctrllog.FromContext(ctx)
-
-	// Start the PipelineRun by removing the pending status
-	log.Info("starting PipelineRun", "name", plr.Name)
-	if err := r.updatePipelineRunState(ctx, plr, "", ""); err != nil {
-		log.Error(err, "failed to start PipelineRun", "name", plr.Name)
-		return false
-	}
-
-	return true
-}
-
 func (r *PipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := ctrllog.FromContext(ctx).WithName("PipelineRunController")
-	ctx = ctrllog.IntoContext(ctx, log)
-
-	// Get all PipelineRuns in the namespace
-	var pipelineRunList tektonv1.PipelineRunList
-	if err := r.Client.List(ctx, &pipelineRunList, client.InNamespace(req.Namespace)); err != nil {
-		log.Error(err, "unable to list PipelineRuns")
-		return ctrl.Result{}, err
-	}
-
-	// Count running PipelineRuns
-	runningCount := 0
-	var pendingRuns []tektonv1.PipelineRun
-
-	for i := range pipelineRunList.Items {
-		run := pipelineRunList.Items[i]
-
-		// Count running PipelineRuns - a running pipelinerun is one that is not pending and not done
-		if !run.IsPending() && !run.IsDone() {
-			runningCount++
-		}
-
-		// Collect pending PipelineRuns
-		if run.IsPending() {
-			pendingRuns = append(pendingRuns, run)
-		}
-	}
-
-	// Sort pending runs by creation timestamp (oldest first)
-	sort.Slice(pendingRuns, func(i, j int) bool {
-		return pendingRuns[i].CreationTimestamp.Before(&pendingRuns[j].CreationTimestamp)
-	})
-
-	// Calculate how many more runs we can start
-	availableSlots := r.Config.PipelineRunConfig.MaxParallelPipelineruns - runningCount
-
-	// Start as many pending runs as possible, up to the maximum allowed
-	if availableSlots > 0 {
-		started := 0
-		for i := 0; i < len(pendingRuns) && started < availableSlots; i++ {
-			if r.startPipelineRun(ctx, pendingRuns[i]) {
-				started++
-				mintmakermetrics.CountScheduledRunSuccess()
-			} else {
-				mintmakermetrics.CountScheduledRunFailure()
-			}
-		}
-		log.Info("started PipelineRuns", "count", started)
-	}
-
 	return ctrl.Result{}, nil
 }
 
@@ -147,12 +55,6 @@ func (r *PipelineRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&tektonv1.PipelineRun{}).
 		WithEventFilter(predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {
-				if e.Object.GetNamespace() != MintMakerNamespaceName {
-					return false
-				}
-				if pipelineRun, ok := e.Object.(*tektonv1.PipelineRun); ok {
-					return pipelineRun.IsPending()
-				}
 				return false
 			},
 			DeleteFunc: func(e event.DeleteEvent) bool {

--- a/internal/pkg/tekton/pipeline_run_builder.go
+++ b/internal/pkg/tekton/pipeline_run_builder.go
@@ -108,7 +108,6 @@ func NewPipelineRunBuilder(name, namespace string) *PipelineRunBuilder {
 				Namespace: namespace,
 			},
 			Spec: tektonv1.PipelineRunSpec{
-				Status: tektonv1.PipelineRunSpecStatusPending,
 				PipelineSpec: &tektonv1.PipelineSpec{
 					Workspaces: []tektonv1.PipelineWorkspaceDeclaration{
 						{

--- a/internal/pkg/tekton/pipeline_run_builder_test.go
+++ b/internal/pkg/tekton/pipeline_run_builder_test.go
@@ -51,8 +51,9 @@ var _ = Describe("PipelineRun builder", func() {
 			Expect(builder.pipelineRun.ObjectMeta.Namespace).To(Equal(namespace))
 		})
 
-		It("should initialize an empty PipelineRunSpec", func() {
-			Expect(builder.pipelineRun.Spec).To(Equal(tektonv1.PipelineRunSpec{}))
+		It("should initialize PipelineRunSpec with default values", func() {
+			Expect(builder.pipelineRun.Spec.Status).To(Equal(tektonv1.PipelineRunSpecStatus("")))
+			Expect(builder.pipelineRun.Spec.PipelineSpec).ToNot(BeNil())
 		})
 	})
 


### PR DESCRIPTION
The upcoming queue system in Konflux cannot properly handle PipelineRuns with a pending status. Therefore, we need to update the controller to create PipelineRuns without setting them to pending status initially.

Previously, setting the pending status was used to control the maximum number of concurrently running PipelineRuns. However, with the introduction of the queue system, we will not be able to control that anymore. Consequently, the related code (which moves PipelineRuns from pending to running status) also needs to be removed.