### PR TITLE
Memory optimization

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -175,9 +175,10 @@ func main() {
 	}
 
 	if err = (&controller.DependencyUpdateCheckReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Config: config.GetConfig(),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
+		Config:    config.GetConfig(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DependencyUpdateCheck")
 		os.Exit(1)
@@ -193,8 +194,9 @@ func main() {
 	}
 
 	if err = (&controller.EventReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Event")
 		os.Exit(1)

--- a/internal/controller/event_controller.go
+++ b/internal/controller/event_controller.go
@@ -38,7 +38,8 @@ import (
 // EventReconciler reconciles a Event object
 type EventReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
 }
 
 // markEventAsProcessed adds an annotation to the event indicating it has been processed
@@ -92,7 +93,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			}
 
 			var plr tektonv1.PipelineRun
-			if err := r.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: plrName}, &plr); err != nil {
+			if err := r.APIReader.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: plrName}, &plr); err != nil {
 				if apierrors.IsNotFound(err) {
 					// The PipelineRun is gone, we can't update it.
 					return
@@ -116,7 +117,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 	}()
 
-	if err := r.Get(ctx, req.NamespacedName, &evt); err != nil {
+	if err := r.APIReader.Get(ctx, req.NamespacedName, &evt); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -142,7 +143,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	podNamespace := evt.InvolvedObject.Namespace
 
 	// Get the actual corresponding Pod object for this event
-	if err := r.Get(ctx, client.ObjectKey{Namespace: podNamespace, Name: podName}, &pod); err != nil {
+	if err := r.APIReader.Get(ctx, client.ObjectKey{Namespace: podNamespace, Name: podName}, &pod); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Pod has gone, we can't proceed
 			return ctrl.Result{}, nil
@@ -165,7 +166,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	// Get the secret
 	var secret corev1.Secret
-	if err := r.Get(ctx, client.ObjectKey{Namespace: podNamespace, Name: secretName}, &secret); err != nil {
+	if err := r.APIReader.Get(ctx, client.ObjectKey{Namespace: podNamespace, Name: secretName}, &secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Secret doesn't exist, in theory this should not happen unless someone
 			// deleted the secret by manual, anyway we will ignore this
@@ -186,7 +187,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 		// Get the component
 		var comp appstudiov1alpha1.Component
-		if err := r.Get(ctx, client.ObjectKey{Namespace: componentNamespace, Name: componentName}, &comp); err != nil {
+		if err := r.APIReader.Get(ctx, client.ObjectKey{Namespace: componentNamespace, Name: componentName}, &comp); err != nil {
 			if apierrors.IsNotFound(err) {
 				// Component has gone, we can't proceed
 				return ctrl.Result{}, nil

--- a/internal/controller/event_controller.go
+++ b/internal/controller/event_controller.go
@@ -23,6 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -230,12 +231,11 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 // SetupWithManager sets up the controller with the Manager.
 func (r *EventReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Event{}).
+		For(&corev1.Event{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			return object.GetNamespace() == MintMakerNamespaceName
+		}))).
 		WithEventFilter(predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {
-				if e.Object.GetNamespace() != MintMakerNamespaceName {
-					return false
-				}
 				evt, ok := e.Object.(*corev1.Event)
 				if !ok {
 					return false

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -105,13 +105,13 @@ var _ = BeforeSuite(func() {
 	Config := config.GetConfig()
 	Expect(Config).NotTo(BeNil())
 
-	err = (NewDependencyUpdateCheckReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), Config, k8sManager.GetEventRecorderFor("DependencyUpdateCheckController"))).SetupWithManager(k8sManager)
+	err = (NewDependencyUpdateCheckReconciler(k8sManager.GetClient(), k8sManager.GetAPIReader(), k8sManager.GetScheme(), Config, k8sManager.GetEventRecorderFor("DependencyUpdateCheckController"))).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&PipelineRunReconciler{Client: k8sManager.GetClient(), Scheme: k8sManager.GetScheme(), Config: Config}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&EventReconciler{Client: k8sManager.GetClient(), Scheme: k8sManager.GetScheme()}).SetupWithManager(k8sManager)
+	err = (&EventReconciler{Client: k8sManager.GetClient(), APIReader: k8sManager.GetAPIReader(), Scheme: k8sManager.GetScheme()}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {


### PR DESCRIPTION
1. Move namespace filtering to controller-level predicates

When use `For(&Resource{})`, cluster-wide informers will be created
for watching resources, but we only want to watch the resources
(DependencyUpdateCheck, PipelineRun, Event) in mintmaker namespace.

Using `builder.WithPredicates()` can filter the resources at informer
level, which happens before caching. This prevents unnecessary informer
creation for resources outside mintmaker namespace, reducing memory
footprint.

2. Replace controller Client with APIReader for some operations

The controller-runtime's Client is designed for active controllers that
frequently access resources. Client.Get/List calls automatically create
informers with permanent caches. However, our controllers have a
different usage pattern.

The reconciliation in DependencyUpdateCheck controller is triggered when
a DependencyUpdateCheck CR is created which is infrequent (can be once
every several hours). It doesn't need cache all cluster components
permanently, and additional resource types discovered through
cross-references. Same issue applies to ServiceAccounts and Secrets
analyzed during component processing.

The reconciliation in event controller is triggered when a pod is unable
to mount a secret, the relevant pods, secrets are processed once in each
reconciliation, we don't need to cache them for future access.

APIReader provides direct HTTP API calls without cache creation, which
fits our infrequent access pattern.

We have some APIs in internal/pkg/component/gitlab that still use the
controller-runtime's Client for listing/getting secrets. They're
unchanged because:

- They may be shared by multiple or even many components, we need
caching to improve performance for repeated access
- Their impact on memory consumption may not be particularly significant

If we discover these calls also heavily consume memory, we may revise
them later.