### PR TITLE
Add namespace filtering back to controller event filters

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -494,10 +494,12 @@ func (r *DependencyUpdateCheckReconciler) SetupWithManager(mgr ctrl.Manager) err
 			return object.GetNamespace() == MintMakerNamespaceName
 		}))).
 		WithEventFilter(predicate.Funcs{
-			CreateFunc:  func(createEvent event.CreateEvent) bool { return true },
-			DeleteFunc:  func(deleteEvent event.DeleteEvent) bool { return false },
-			UpdateFunc:  func(updateEvent event.UpdateEvent) bool { return false },
-			GenericFunc: func(genericEvent event.GenericEvent) bool { return false },
+			CreateFunc: func(e event.CreateEvent) bool {
+				return e.Object.GetNamespace() == MintMakerNamespaceName
+			},
+			DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+			UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+			GenericFunc: func(e event.GenericEvent) bool { return false },
 		}).
 		Complete(r)
 }

--- a/internal/controller/event_controller.go
+++ b/internal/controller/event_controller.go
@@ -237,6 +237,9 @@ func (r *EventReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}))).
 		WithEventFilter(predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {
+				if e.Object.GetNamespace() != MintMakerNamespaceName {
+					return false
+				}
 				evt, ok := e.Object.(*corev1.Event)
 				if !ok {
 					return false

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -64,6 +64,9 @@ func (r *PipelineRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return false
 			},
 			UpdateFunc: func(e event.UpdateEvent) bool {
+				if e.ObjectNew.GetNamespace() != MintMakerNamespaceName {
+					return false
+				}
 				if oldPipelineRun, ok := e.ObjectOld.(*tektonv1.PipelineRun); ok {
 					if newPipelineRun, ok := e.ObjectNew.(*tektonv1.PipelineRun); ok {
 						if !oldPipelineRun.IsDone() && newPipelineRun.IsDone() {


### PR DESCRIPTION
The builder-level predicates added in commit 6ae8669 should filter at informer level, but seems events from other namespaces are still reaching controller event filters.

From observation, it seems that only logging in event filters is affected, and the events are not actually processed by Reconcile. Until the exact impact is confirmed, restore the namespace filter to ensure correctness.