### PR TITLE
Log pipeline run creation

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -344,6 +344,8 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(name string, comp co
 	}
 	if err := r.Client.Create(ctx, pipelineRun); err != nil {
 		return nil, err
+	} else {
+		log.Info(fmt.Sprintf("created PipelineRun %s", pipelineRun.Name))
 	}
 	resources = append(resources, pipelineRun)
 


### PR DESCRIPTION
I think this was removed in https://github.com/konflux-ci/mintmaker/pull/124/files#diff-6ee488054ff91ac0d672f08cab779dd8cad2c316321eb9d190c3a9847ff851caL150 but it is used in our Splunk dashboard to track the scheduled runs.