### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+insert_final_newline = true
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.go]
+indent_size = 4
+indent_style = tab
+
+[*.yaml]
+indent_size = 2


### PR DESCRIPTION
I noticed that some editors sometimes remove newlines at the end of files or make other unnecessary whitespace changes that increase the noise when doing a code review. This config should help with that.