### PR TITLE
Add auto assign action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,0 @@
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence, these
-# owners will be requested for review when someone opens a
-# pull request.
-*  @tonisbones @qixiang @staticf0x @FernandesMF @querti @KristianTkacik @HozifaWasfy

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,13 @@
+addReviewers: true
+addAssignees: false
+
+reviewers:
+  - tonisbones
+  - qixiang
+  - staticf0x
+  - FernandesMF
+  - querti
+  - KristianTkacik
+  - HozifaWasfy
+
+numberOfReviewers: 2

--- a/.github/workflows/auto-assign-prs.yml
+++ b/.github/workflows/auto-assign-prs.yml
@@ -1,0 +1,10 @@
+name: "Auto Assign"
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@f4648c0a9fdb753479e9e75fc251f507ce17bb7e # v2.0.0


### PR DESCRIPTION
Trying out the GitHub action that will assign reviewers to new PRs. I removed `CODEOWNERS` because it causes everyone from the list to be a reviewer and could interfere with this action. The action is pinned to a specific commit instead of a tag to prevent hijacks that already happened recently on GitHub.