### PR TITLE
Fix incorrect hostRules assignment for components

### DIFF
--- a/internal/pkg/component/github/github.go
+++ b/internal/pkg/component/github/github.go
@@ -367,9 +367,17 @@ func (c *Component) GetRenovateConfig(registrySecret *corev1.Secret) (string, er
 		return GetRenovateConfigFn(registrySecret)
 	}
 
-	baseConfig, err := c.GetRenovateBaseConfig(c.client, c.ctx, registrySecret)
+	baseConfig, err := c.GetRenovateBaseConfig(c.ctx, c.client)
 	if err != nil {
 		return "", err
+	}
+
+	// Add component-specific hostRules if registrySecret is provided
+	if registrySecret != nil {
+		hostRules, err := c.GetHostRules(c.ctx, registrySecret)
+		if err == nil && len(hostRules) > 0 {
+			baseConfig["hostRules"] = hostRules
+		}
 	}
 	appSlug, err := c.getAppSlug()
 	if err != nil {

--- a/internal/pkg/component/gitlab/gitlab.go
+++ b/internal/pkg/component/gitlab/gitlab.go
@@ -206,9 +206,17 @@ func (c *Component) getDefaultBranch() (string, error) {
 }
 
 func (c *Component) GetRenovateConfig(registrySecret *corev1.Secret) (string, error) {
-	baseConfig, err := c.GetRenovateBaseConfig(c.client, c.ctx, registrySecret)
+	baseConfig, err := c.GetRenovateBaseConfig(c.ctx, c.client)
 	if err != nil {
 		return "", err
+	}
+
+	// Add component-specific hostRules if registrySecret is provided
+	if registrySecret != nil {
+		hostRules, err := c.GetHostRules(c.ctx, registrySecret)
+		if err == nil && len(hostRules) > 0 {
+			baseConfig["hostRules"] = hostRules
+		}
 	}
 
 	baseConfig["platform"] = c.Platform


### PR DESCRIPTION
While generating Renovate configuration for components, the component-specific hostRules are added to the global variable shared across all components, this caused components are using the hostRules created for the first component.

Changes:
- Rename TransformHostRules to GetHostRules
- Move hostRules generation to platform-specific GetRenovateConfig methods
- Update GetRenovateBaseConfig parameter order (context first, following Go conventions)