### PR TITLE
Fix job launch metrics

### DIFF
--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -382,6 +382,11 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(name string, comp co
 // +kubebuilder:rbac:groups=appstudio.redhat.com,resources=dependencyupdatechecks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=appstudio.redhat.com,resources=dependencyupdatechecks/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=appstudio.redhat.com,resources=dependencyupdatechecks/finalizers,verbs=update
+// +kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch
+// +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -498,6 +503,7 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 				"branch", branch,
 				"repository", repository,
 				"host", host)
+			mintmakermetrics.CountScheduledRunFailure()
 		} else {
 			log.Info("created PipelineRun",
 				"component", appstudioComponent.Name,
@@ -505,6 +511,7 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 				"repository", repository,
 				"host", host,
 				"PipelineRun", pipelinerun.Name)
+			mintmakermetrics.CountScheduledRunSuccess()
 		}
 	}
 

--- a/internal/controller/event_controller.go
+++ b/internal/controller/event_controller.go
@@ -64,7 +64,7 @@ func (r *EventReconciler) markEventAsProcessed(ctx context.Context, event *corev
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events/finalizers,verbs=update
-// +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns;pipelineruns/status,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns;pipelineruns/status,verbs=get;list;watch;create;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/pkg/metrics/common.go
+++ b/internal/pkg/metrics/common.go
@@ -15,8 +15,8 @@ var (
 	controllerAvailabilityVec = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: "mintmaker",
-			Name:      "availability",
-			Help:      "Number of successfully scheduled MintMaker PipelineRuns and failures",
+			Name:      "pipelinerun_scheduled",
+			Help:      "Number of scheduled MintMaker PipelineRuns (successes and failures)",
 		},
 		[]string{"status"}, // "success" or "failure"
 	)


### PR DESCRIPTION
This commit fixes the job launch metrics, which became inoperative after changes to the pipelinerun controller.

Previously, the metrics on job launching/scheduling were called during the pipelinerun controller reconcile loop. However, since Keue was adopted, this controller loop was removed, since it does not need to manage the pipeline run launches anymore.

This commit reintroduces the metric in the DUC controller, and makes the metric opperative once again.

Full disclosure: assisted by Cursor

### Testing remarks
I tested these changes manually, in my local minikube cluster, and I could see the metric showing again in the '/metrics' endpoint.