### PR TITLE
Enable cargo manager

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -65,7 +65,8 @@
     "gomod",
     "ocb",
     "gitlabci",
-    "gitlabci-include"
+    "gitlabci-include",
+    "cargo"
   ],
   "tekton": {
     "managerFilePatterns": [


### PR DESCRIPTION
- We already have `rustc` and `cargo` installed in the image
- E2E tests were added