### PR TITLE
Enable configMigration

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -15,6 +15,7 @@
   "autodiscover": false,
   "pruneStaleBranches": false,
   "branchConcurrentLimit": 0,
+  "configMigration": true,
   "containerVulnerabilityAlerts": true,
   "rpmVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#configmigration

Proposing to turn this on, it would make it much easier for our users to keep up with the changes. I have been testing it on my repos, and while the documentation claims it's an experimental feature, I haven't noticed any problems at all:

> Config migration PRs are still being improved, in particular to reduce the amount of reordering and whitespace changes.

If it is only regarding whitespace and key reordering, I think we should be safe to enable this.