### PR TITLE
Re-enable pre-commit and git-submodules

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -566,6 +566,12 @@
     "rebaseWhen": "behind-base-branch",
     "branchTopic": "lock-file-maintenance"
   },
+  "git-submodules": {
+    "enabled": true
+  },
+  "pre-commit": {
+    "enabled": true
+  },
   "gomod": {
     "postUpdateOptions": [
       "gomodUpdateImportPaths",


### PR DESCRIPTION
This was accidentally removed during #364 

`pre-commit` is disabled by default, so we need the explicit `enabled: true`

Edit: same with `git-submodules`