### PR TITLE
feat: Send PipelineRun successes and failures to KITE API

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -203,9 +203,10 @@ func main() {
 	}
 
 	if err = (&controller.PipelineRunReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Config: config.GetConfig(),
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		Config:     config.GetConfig(),
+		KiteClient: kiteClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PipelineRun")
 		os.Exit(1)

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -29,8 +30,10 @@ import (
 
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
+	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/mintmaker/internal/pkg/config"
 	. "github.com/konflux-ci/mintmaker/internal/pkg/constant"
+	"github.com/konflux-ci/mintmaker/internal/pkg/kite"
 )
 
 var (
@@ -41,13 +44,83 @@ var (
 
 // PipelineRunReconciler reconciles a PipelineRun object
 type PipelineRunReconciler struct {
-	Client client.Client
-	Scheme *runtime.Scheme
-	Config *config.ControllerConfig
+	Client     client.Client
+	Scheme     *runtime.Scheme
+	Config     *config.ControllerConfig
+	KiteClient *kite.Client
 }
 
 func (r *PipelineRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
+}
+
+func (r *PipelineRunReconciler) handlePipelinerunCompletion(ctx context.Context, pipelineRun *tektonv1.PipelineRun) error {
+	condition := pipelineRun.Status.GetCondition(apis.ConditionSucceeded)
+	if condition == nil {
+		return fmt.Errorf("PipelineRun condition is nil")
+	}
+
+	if r.KiteClient == nil {
+		return fmt.Errorf("KITE client not available")
+	}
+
+	// Fetch the Component associated with this PipelineRun
+	component := &appstudiov1alpha1.Component{}
+	err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      pipelineRun.Labels[MintMakerComponentNameLabel],
+		Namespace: pipelineRun.Labels[MintMakerComponentNamespaceLabel],
+	}, component)
+
+	if err != nil {
+		return fmt.Errorf("failed to fetch Component %s/%s: %w",
+			pipelineRun.Labels[MintMakerComponentNamespaceLabel], pipelineRun.Labels[MintMakerComponentNameLabel], err)
+	}
+
+	// Construct a unique pipeline identifier using the Git URL and revision (branch)
+	pipelineIdentifier := fmt.Sprintf("%s/%s", component.Spec.Source.GitSource.URL, component.Spec.Source.GitSource.Revision)
+
+	// Check if the PipelineRun failed or succeeded and send the appropriate webhook
+	log := ctrl.Log.WithName("PipelineRunController")
+	if condition.IsTrue() {
+		if err := r.sendSuccessWebhook(ctx, pipelineRun, pipelineIdentifier); err != nil {
+			return err
+		} else {
+			log.Info("Succesfully sent PipelineRun success webhook", "pipelineRun", pipelineRun.Name, "pipelineIdentifier", pipelineIdentifier)
+		}
+	} else {
+		if err := r.sendFailureWebhook(ctx, pipelineRun, pipelineIdentifier); err != nil {
+			return err
+		} else {
+			// Log the failure reason
+			reason := pipelineRun.Status.GetCondition(apis.ConditionSucceeded).GetReason()
+			log.Info("Succesfully sent PipelineRun failure webhook", "pipelineRun", pipelineRun.Name, "reason", reason, "pipelineIdentifier", pipelineIdentifier)
+		}
+	}
+	return nil
+}
+
+func (r *PipelineRunReconciler) sendFailureWebhook(ctx context.Context, pipelineRun *tektonv1.PipelineRun, pipelineIdentifier string) error {
+	// Get failure reason
+	reason := pipelineRun.Status.GetCondition(apis.ConditionSucceeded).GetReason()
+
+	payload := kite.PipelineFailurePayload{
+		PipelineName:  pipelineIdentifier,
+		Namespace:     pipelineRun.Labels[MintMakerComponentNamespaceLabel],
+		FailureReason: reason,
+		RunID:         pipelineRun.Name,
+		LogsURL:       "", // Placeholder for logs URL if available
+	}
+
+	return r.KiteClient.SendPipelineFailure(ctx, payload)
+}
+
+func (r *PipelineRunReconciler) sendSuccessWebhook(ctx context.Context, pipelineRun *tektonv1.PipelineRun, pipelineIdentifier string) error {
+	payload := kite.PipelineSuccessPayload{
+		PipelineName: pipelineIdentifier,
+		Namespace:    pipelineRun.Labels[MintMakerComponentNamespaceLabel],
+	}
+
+	return r.KiteClient.SendPipelineSuccess(ctx, payload)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -72,6 +145,11 @@ func (r *PipelineRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						if !oldPipelineRun.IsDone() && newPipelineRun.IsDone() {
 							if newPipelineRun.Status.CompletionTime != nil {
 								log := ctrl.Log.WithName("PipelineRunController")
+								// send PipelineRun completion status to KITE webhook
+								if err := r.handlePipelinerunCompletion(context.Background(), newPipelineRun); err != nil {
+									log.Error(err, "Failed to send PipelineRun status to KITE", "pipelineRun", newPipelineRun.Name)
+								}
+
 								log.Info(
 									fmt.Sprintf("PipelineRun finished: %s", newPipelineRun.Name),
 									"completionTime",


### PR DESCRIPTION
Add functions for sending requests to defined webhooks. Extend pipelinerun_controller Reconcile function to watch for pipelinerun failure and success and send corresponding requests.

{"error":"Missing namespace"} bug resolved - add namespace as query param

CWFHEALTH-4404