### PR TITLE
Re-enable lockFileMaintenance schedule

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -558,14 +558,18 @@
   },
   "rpm-lockfile": {
     "lockFileMaintenance": {
-      "enabled": true
+      "enabled": true,
+      "schedule": ["before 5am"]
     }
   },
   "lockFileMaintenance": {
     "enabled": true,
     "recreateWhen": "always",
     "rebaseWhen": "behind-base-branch",
-    "branchTopic": "lock-file-maintenance"
+    "branchTopic": "lock-file-maintenance",
+    "schedule": [
+      "before 5am"
+    ]
   },
   "git-submodules": {
     "enabled": true


### PR DESCRIPTION
This overrides the default Renovate schedule for lockFileMaintenance (before 4am on monday).

JIRA: CWFHEALTH-4474