### PR TITLE
Configure Renovate gomod updates for weekends only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "tekton": {
     "enabled": true,
     "automergeType": "pr",
@@ -18,6 +19,7 @@
     ]
   },
   "gomod": {
+    "schedule": ["* * * * 0,6"],
     "packageRules": [
       {
         "matchDatasources": ["go"],


### PR DESCRIPTION
This reduces weekday noise from go dependency updates.