### PR TITLE
refactor: move context.Context to first parameter

### DIFF
--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Get only components that match a given namespace/application/componentname
-func getFilteredComponents(namespaces []mmv1alpha1.NamespaceSpec, apiClient client.Client, ctx context.Context) ([]appstudiov1alpha1.Component, error) {
+func getFilteredComponents(ctx context.Context, namespaces []mmv1alpha1.NamespaceSpec, apiClient client.Client) ([]appstudiov1alpha1.Component, error) {
 	components := []appstudiov1alpha1.Component{}
 	err := error(nil)
 

--- a/internal/controller/event_controller.go
+++ b/internal/controller/event_controller.go
@@ -197,7 +197,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 
 		// Create GitComponent from Component
-		gitComp, err := component.NewGitComponent(&comp, r.Client, ctx)
+		gitComp, err := component.NewGitComponent(ctx, &comp, r.Client)
 		if err != nil {
 			errMessage = err.Error()
 			// Do not requeue, the error is not related to the cluster issues

--- a/internal/pkg/component/base/base.go
+++ b/internal/pkg/component/base/base.go
@@ -177,7 +177,7 @@ func getActivationKeyFromSecret(secret *corev1.Secret) (string, string, error) {
 }
 
 // returns two strings, activationkey and org
-func (c *BaseComponent) GetRPMActivationKey(k8sClient client.Client, ctx context.Context) (string, string, error) {
+func (c *BaseComponent) GetRPMActivationKey(ctx context.Context, k8sClient client.Client) (string, string, error) {
 
 	defaultSecret := &corev1.Secret{}
 	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: c.Namespace, Name: "activation-key"}, defaultSecret); err != nil {

--- a/internal/pkg/component/component.go
+++ b/internal/pkg/component/component.go
@@ -40,10 +40,10 @@ type GitComponent interface {
 	GetBranch() (string, error)
 	GetAPIEndpoint() string
 	GetRenovateConfig(*corev1.Secret) (string, error)
-	GetRPMActivationKey(client.Client, context.Context) (string, string, error)
+	GetRPMActivationKey(context.Context, client.Client) (string, string, error)
 }
 
-func NewGitComponent(comp *appstudiov1alpha1.Component, client client.Client, ctx context.Context) (GitComponent, error) {
+func NewGitComponent(ctx context.Context, comp *appstudiov1alpha1.Component, client client.Client) (GitComponent, error) {
 	// First check if source url exists and is properly defined
 	if comp.Spec.Source.GitSource == nil || comp.Spec.Source.GitSource.URL == "" {
 		return nil, fmt.Errorf("component %s has no git source or empty URL defined", comp.Name)
@@ -55,13 +55,13 @@ func NewGitComponent(comp *appstudiov1alpha1.Component, client client.Client, ct
 
 	switch platform {
 	case "github":
-		c, err := github.NewComponent(comp, client, ctx)
+		c, err := github.NewComponent(ctx, comp, client)
 		if err != nil {
 			return nil, fmt.Errorf("error creating git component: %w", err)
 		}
 		return c, nil
 	case "gitlab":
-		c, err := gitlab.NewComponent(comp, client, ctx)
+		c, err := gitlab.NewComponent(ctx, comp, client)
 		if err != nil {
 			return nil, fmt.Errorf("error creating git component: %w", err)
 		}

--- a/internal/pkg/component/github/github.go
+++ b/internal/pkg/component/github/github.go
@@ -65,7 +65,7 @@ type Component struct {
 	ctx           context.Context
 }
 
-func getAppIDAndKey(client client.Client, ctx context.Context) (int64, []byte, error) {
+func getAppIDAndKey(ctx context.Context, client client.Client) (int64, []byte, error) {
 	if ghAppID != 0 && ghAppPrivateKey != nil {
 		return ghAppID, ghAppPrivateKey, nil
 	}
@@ -86,8 +86,8 @@ func getAppIDAndKey(client client.Client, ctx context.Context) (int64, []byte, e
 	return ghAppID, ghAppPrivateKey, nil
 }
 
-func NewComponent(comp *appstudiov1alpha1.Component, client client.Client, ctx context.Context) (*Component, error) {
-	appID, appPrivateKey, err := getAppIDAndKey(client, ctx)
+func NewComponent(ctx context.Context, comp *appstudiov1alpha1.Component, client client.Client) (*Component, error) {
+	appID, appPrivateKey, err := getAppIDAndKey(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get GitHub APP ID and private key: %w", err)
 	}
@@ -328,7 +328,7 @@ func (c *Component) GetAPIEndpoint() string {
 }
 
 func (c *Component) getAppSlug() (string, error) {
-	appID, appPrivateKey, err := getAppIDAndKey(c.client, c.ctx)
+	appID, appPrivateKey, err := getAppIDAndKey(c.ctx, c.client)
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/component/gitlab/gitlab.go
+++ b/internal/pkg/component/gitlab/gitlab.go
@@ -46,7 +46,7 @@ type Repository struct {
 	Repository   string
 }
 
-func NewComponent(comp *appstudiov1alpha1.Component, client client.Client, ctx context.Context) (*Component, error) {
+func NewComponent(ctx context.Context, comp *appstudiov1alpha1.Component, client client.Client) (*Component, error) {
 	giturl := comp.Spec.Source.GitSource.URL
 	// TODO: a helper to validate and parse the git url
 	platform, err := utils.GetGitPlatform(giturl)


### PR DESCRIPTION
Some functions are not following Go's idiomatic convention where context.Context should be the first parameter. This updates these functions to improve consistency and aligns with Go best practices.

Assisted-by: Claude Code