### PR TITLE
Ignore untestable paths in CodeCov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,8 @@
 ignore:
   - "api/v1alpha1/zz_generated.deepcopy.go"
+  - "api/v1alpha1/dependencyupdatecheck_types.go"
+  - "**/mock_*.go"
+  - "cmd/"
 
 codecov:
   require_ci_to_pass: true


### PR DESCRIPTION
This change ignores files that are either generated (mocks) or cannot be covered by unit tests (`cmd/`). By doing this we should get closer coverage between https://konflux-ci.dev/coverage-dashboard/ (43.9%) and CodeCov (19.64%). Even after this PR the file list will be slightly different though.

**Konflux coverage dashboard**:

```
internal/component/github/cache.go
internal/component/github/github.go
internal/controller/common.go
internal/controller/dependencyupdatecheck_controller.go
internal/controller/event_controller.go
internal/controller/pipelinerun_controller.go
internal/tekton/pipeline_run_builder.go
internal/utils/random.go
internal/utils/sanitize.go
internal/utils/utils.go
tools/osv-generator/cve_parser.go
tools/osv-generator/generator.go
```

**CodeCov** (before this PR):

```
api/v1alpha1/dependencyupdatecheck_types.go
cmd/manager/main.go
cmd/osv-generator/main.go
internal/component/base/base.go
internal/component/component.go
internal/component/forgejo/forgejo.go
internal/component/github/cache.go
internal/component/github/github.go
internal/component/gitlab/gitlab.go
internal/component/mocks/mock_GitComponent.go
internal/config/config.go
internal/controller/common.go
internal/controller/dependencyupdatecheck_controller.go
internal/controller/event_controller.go
internal/controller/pipelinerun_controller.go
internal/metrics/backend_probe.go
internal/metrics/common.go
internal/slices/slice.go
internal/tekton/pipeline_run_builder.go
internal/utils/random.go
internal/utils/sanitize.go
internal/utils/utils.go
test/utils/utils.go
tools/osv-downloader/download_osv.go
tools/osv-generator/cve_parser.go
tools/osv-generator/generator.go
```

**CodeCov** (after this PR):

```
internal/component/base/base.go
internal/component/component.go
internal/component/forgejo/forgejo.go
internal/component/github/cache.go
internal/component/github/github.go
internal/component/gitlab/gitlab.go
internal/config/config.go
internal/controller/common.go
internal/controller/dependencyupdatecheck_controller.go
internal/controller/event_controller.go
internal/controller/pipelinerun_controller.go
internal/metrics/backend_probe.go
internal/metrics/common.go
internal/slices/slice.go
internal/tekton/pipeline_run_builder.go
internal/utils/random.go
internal/utils/sanitize.go
internal/utils/utils.go
test/utils/utils.go
tools/osv-downloader/download_osv.go
tools/osv-generator/cve_parser.go
tools/osv-generator/generator.go
```