### PR TITLE
Add refresh-rpm-lockfiles to allowed commands

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -620,7 +620,8 @@
   "forkProcessing": "enabled",
   "allowedCommands": [
     "^rpm-lockfile-prototype rpms.in.yaml$",
-    "^pipeline-migration-tool migrate -f \"\\$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\"$"
+    "^pipeline-migration-tool migrate -f \"\\$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\"$",
+    "^refresh-rpm-lockfiles -f \"\\$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\"$"
   ],
   "updateNotScheduled": false,
   "dependencyDashboard": false,


### PR DESCRIPTION
This is for https://github.com/konflux-ci/refresh-rpm-lockfiles

No more config should be done here I think, I'd like to keep the config separate in https://github.com/konflux-ci/mintmaker-presets so that users can choose whether to run this command individually.

I'd also like to invite you all to review https://github.com/konflux-ci/refresh-rpm-lockfiles as I was pushing commits for the initial version.