### PR TITLE
feat(renovate): prefix Mintmaker PR titles and commits with base branch

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -25,6 +25,7 @@
   },
   "additionalBranchPrefix": "{{baseBranch}}/",
   "branchPrefix": "konflux/mintmaker/",
+  "commitMessagePrefix": "[{{baseBranch}}] ",
   "enabledManagers": [
     "github-actions",
     "tekton",


### PR DESCRIPTION
## Summary

Set a top-level `commitMessagePrefix` in the shared Mintmaker Renovate config so that pull request titles and commit messages include the target base branch (for example `[release-1.19] …`, `[main] …`) for easier identification.

## Change

Add `"commitMessagePrefix": "[{{baseBranch}}] "` to `config/renovate/renovate.json`.

## Notes

Repos that set their own `commitMessagePrefix` continue to override this preset.

## References

[Renovate commitMessagePrefix](https://docs.renovatebot.com/configuration-options/#commitmessageprefix)
[Renovate templates (baseBranch)](https://docs.renovatebot.com/templates/)