### PR TITLE
Make replacement PR titles more clear

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -135,7 +135,7 @@
         "branchPrefix": "konflux/references-replacement/",
         "groupName": "Konflux references replacement",
         "group": {
-          "commitMessageTopic": "redhat-appstudio-tekton-catalog references",
+          "commitMessageTopic": "{{depName}} references",
           "commitMessageExtra": "",
           "commitBody": "redhat-appstudio-tekton-catalog is deprecated, replace the references\nwith equivalent konflux-ci/tekton-catalog references"
         }


### PR DESCRIPTION
In Renovate v43 grouping of replacement updates is no longer supported See https://github.com/renovatebot/renovate/pull/40758/changes

This commit will add the depName (including the host) to the PR title for clarity.