### PR TITLE
Make MM resources readable to Konflux users

### DIFF
--- a/config/rbac/konflux_viewers.yaml
+++ b/config/rbac/konflux_viewers.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: mintmaker
+    app.kubernetes.io/managed-by: kustomize
+  name: mintmaker-tenant-konflux-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
+

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- konflux_viewers.yaml
 # The following RBAC configurations are used to protect
 # the metrics endpoint with authn/authz. These configurations
 # ensure that only authorized users and service accounts


### PR DESCRIPTION
This commit enables any user authenticated in the Konflux cluster to read Konflux resources in the MintMaker namespace. The access is given via the 'konflux-viewer-user-actions' ClusterRole.

This will be important to enable the UI to view pipelineruns and their logs.

We are replicating the strategy from the rhtap-release tenant.

Assisted by: Claude

### Remarks
- the permissions of the 'konflux-viewer-user-actions' ClusterRole can be checked [here](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-viewer-user-actions.yaml)
- `make generate manifests` didn't produce any changes to the files involved in this PR