### PR TITLE
Set minimumReleaseAge for update cooldowns

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -23,6 +23,8 @@
   "vulnerabilityAlerts": {
     "enabled": true
   },
+  "minimumReleaseAge": "3 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "additionalBranchPrefix": "{{baseBranch}}/",
   "branchPrefix": "konflux/mintmaker/",
   "enabledManagers": [


### PR DESCRIPTION
Docs: https://docs.renovatebot.com/key-concepts/minimum-release-age/ and https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour

This should hopefully mitigate some of the supply chain attacks. Users can still override this options. Also worth noting, that some of MintMaker users already use this option.