### PR TITLE
Set prCreation to disallow proposing PRs before minimumReleaseAge

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -25,6 +25,7 @@
   },
   "minimumReleaseAge": "3 days",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "prCreation": "not-pending",
   "additionalBranchPrefix": "{{baseBranch}}/",
   "branchPrefix": "konflux/mintmaker/",
   "enabledManagers": [


### PR DESCRIPTION
See https://docs.renovatebot.com/configuration-options/#prcreation and https://docs.renovatebot.com/configuration-options/#minimumreleaseage