### PR TITLE
Implement log sanitization step

### DIFF
--- a/internal/constant/constants.go
+++ b/internal/constant/constants.go
@@ -31,4 +31,7 @@ const (
 
 	RenovateImageEnvName    = "RENOVATE_IMAGE"
 	DefaultRenovateImageURL = "quay.io/konflux-ci/mintmaker-renovate-image:latest"
+
+	LeakTKImageEnvName    = "LEAKTK_IMAGE"
+	DefaultLeakTKImageURL = "quay.io/leaktk/leaktk:latest"
 )

--- a/internal/tekton/log_sanitizer.sh
+++ b/internal/tekton/log_sanitizer.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+LOG_FILE="${LOG_FILE:-/workspace/shared-data/renovate-logs.json}"
+FAIL_MSG='Sanitization step failed; the entire logs of this execution were removed for caution'
+fail_safe() {
+  echo "$FAIL_MSG"
+  echo "$FAIL_MSG" > "$LOG_FILE"
+  exit 0
+}
+if [ ! -f "$LOG_FILE" ]; then
+  echo 'Log file not found, skipping sanitization'
+  exit 0
+fi
+echo 'Scanning log file for leaked secrets...'
+SCAN_OUTPUT=$(leaktk scan --kind JSONData "@${LOG_FILE}" 2>/dev/null)
+if [ $? -ne 0 ]; then
+  echo 'leaktk scan failed'
+  fail_safe
+fi
+if [ -z "$SCAN_OUTPUT" ]; then
+  echo 'No secrets detected or scanner produced no output'
+  exit 0
+fi
+SECRETS=$(echo "$SCAN_OUTPUT" | python3 -c "
+import sys, json
+for r in json.load(sys.stdin).get('results',[]):
+    s = r.get('secret','')
+    if s: print(s)
+")
+if [ $? -ne 0 ]; then
+  echo 'Failed to parse leaktk output'
+  fail_safe
+fi
+if [ -z "$SECRETS" ]; then
+  echo 'No secrets found in log file'
+  exit 0
+fi
+if ! cp "$LOG_FILE" "${LOG_FILE}.tmp"; then
+  echo 'Failed to create temporary log file'
+  fail_safe
+fi
+REDACT_FAILED=0
+while IFS= read -r secret; do
+  if [ -n "$secret" ]; then
+    # Prepend '\' to BRE metacharacters and the sed delimiter (|) so sed treats them as literal characters
+    ESCAPED=$(printf '%s\n' "$secret" | sed 's/[[\.*^$|\\]/\\&/g')
+    if ! sed -i "s|${ESCAPED}|**REDACTED**|g" "${LOG_FILE}.tmp"; then
+      REDACT_FAILED=1
+      break
+    fi
+  fi
+done <<EOF
+$SECRETS
+EOF
+if [ "$REDACT_FAILED" -eq 1 ]; then
+  echo 'Failed to redact secrets from log file'
+  fail_safe
+fi
+if ! mv "${LOG_FILE}.tmp" "$LOG_FILE"; then
+  echo 'Failed to replace log file with redacted version'
+  fail_safe
+fi
+echo 'Log sanitization complete'

--- a/internal/tekton/log_sanitizer_test.go
+++ b/internal/tekton/log_sanitizer_test.go
@@ -1,0 +1,224 @@
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tekton
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func writeStub(dir, name, script string) {
+	path := filepath.Join(dir, name)
+	err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0755) //nolint:gosec // test stub needs to be executable
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func runSanitizer(scriptPath, logFile, mockDir string) (string, int) {
+	cmd := exec.Command("sh", scriptPath) //nolint:gosec // test helper runs the script under test
+	cmd.Env = []string{
+		"LOG_FILE=" + logFile,
+		"PATH=" + mockDir + ":/usr/bin:/bin",
+		"HOME=/tmp",
+	}
+	var outBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &outBuf
+	err := cmd.Run()
+	exitCode := 0
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		exitCode = exitErr.ExitCode()
+	} else if err != nil {
+		exitCode = -1
+	}
+	return outBuf.String(), exitCode
+}
+
+var _ = Describe("log_sanitizer.sh", func() {
+	var (
+		tmpDir     string
+		mockDir    string
+		logFile    string
+		scriptFile string
+	)
+
+	BeforeEach(func() {
+		tmpDir = GinkgoT().TempDir()
+		mockDir = filepath.Join(tmpDir, "mocks")
+		Expect(os.Mkdir(mockDir, 0750)).To(Succeed())
+		logFile = filepath.Join(tmpDir, "renovate-logs.json")
+		scriptFile = filepath.Join(tmpDir, "log_sanitizer.sh")
+		Expect(os.WriteFile(scriptFile, []byte(logSanitizerScript), 0600)).To(Succeed())
+	})
+
+	When("log file does not exist", func() {
+		It("should skip sanitization", func() {
+			output, exitCode := runSanitizer(scriptFile, logFile, mockDir)
+
+			Expect(exitCode).To(Equal(0))
+			Expect(output).To(ContainSubstring("Log file not found, skipping sanitization"))
+		})
+	})
+
+	When("leaktk scan fails", func() {
+		BeforeEach(func() {
+			Expect(os.WriteFile(logFile, []byte(`{"some": "log"}`), 0600)).To(Succeed())
+			writeStub(mockDir, "leaktk", `echo "scan error" >&2; exit 1`)
+		})
+
+		It("should call fail_safe and overwrite the log file", func() {
+			output, exitCode := runSanitizer(scriptFile, logFile, mockDir)
+
+			Expect(exitCode).To(Equal(0))
+			Expect(output).To(ContainSubstring("leaktk scan failed"))
+			logContent, err := os.ReadFile(logFile) //nolint:gosec // test assertion
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(logContent)).To(ContainSubstring("Sanitization step failed"))
+		})
+	})
+
+	When("leaktk returns empty stdout", func() {
+		BeforeEach(func() {
+			Expect(os.WriteFile(logFile, []byte(`{"some": "log"}`), 0600)).To(Succeed())
+			writeStub(mockDir, "leaktk", `exit 0`)
+		})
+
+		It("should report no secrets detected", func() {
+			output, exitCode := runSanitizer(scriptFile, logFile, mockDir)
+
+			Expect(exitCode).To(Equal(0))
+			Expect(output).To(ContainSubstring("No secrets detected or scanner produced no output"))
+			logContent, err := os.ReadFile(logFile) //nolint:gosec // test assertion
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(logContent)).To(Equal(`{"some": "log"}`))
+		})
+	})
+
+	When("python3 parsing fails", func() {
+		BeforeEach(func() {
+			Expect(os.WriteFile(logFile, []byte(`{"some": "log"}`), 0600)).To(Succeed())
+			writeStub(mockDir, "leaktk", `echo '{"results": [{"secret": "abc"}]}'`)
+			writeStub(mockDir, "python3", `exit 1`)
+		})
+
+		It("should call fail_safe and overwrite the log file", func() {
+			output, exitCode := runSanitizer(scriptFile, logFile, mockDir)
+
+			Expect(exitCode).To(Equal(0))
+			Expect(output).To(ContainSubstring("Failed to parse leaktk output"))
+			logContent, err := os.ReadFile(logFile) //nolint:gosec // test assertion
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(logContent)).To(ContainSubstring("Sanitization step failed"))
+		})
+	})
+
+	When("leaktk returns results JSON but no secrets in it", func() {
+		BeforeEach(func() {
+			Expect(os.WriteFile(logFile, []byte(`{"some": "log"}`), 0600)).To(Succeed())
+			writeStub(mockDir, "leaktk", `echo '{"results": []}'`)
+			writeStub(mockDir, "python3", `echo ""`)
+		})
+
+		It("should report no secrets found", func() {
+			output, exitCode := runSanitizer(scriptFile, logFile, mockDir)
+
+			Expect(exitCode).To(Equal(0))
+			Expect(output).To(ContainSubstring("No secrets found in log file"))
+			logContent, err := os.ReadFile(logFile) //nolint:gosec // test assertion
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(logContent)).To(Equal(`{"some": "log"}`))
+		})
+	})
+
+	When("secrets are found", func() {
+		BeforeEach(func() {
+			Expect(os.WriteFile(logFile, []byte(`{"msg": "token my-secret-value here"}`), 0600)).To(Succeed())
+			writeStub(mockDir, "leaktk", `echo '{"results": [{"secret": "my-secret-value"}]}'`)
+			writeStub(mockDir, "python3", `echo "my-secret-value"`)
+		})
+
+		It("should redact the secret from the log file", func() {
+			output, exitCode := runSanitizer(scriptFile, logFile, mockDir)
+
+			Expect(exitCode).To(Equal(0))
+			Expect(output).To(ContainSubstring("Log sanitization complete"))
+			logContent, err := os.ReadFile(logFile) //nolint:gosec // test assertion
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(logContent)).To(Equal(`{"msg": "token **REDACTED** here"}`))
+			Expect(string(logContent)).NotTo(ContainSubstring("my-secret-value"))
+		})
+	})
+
+	When("cp fails to create the temporary file", func() {
+		BeforeEach(func() {
+			Expect(os.WriteFile(logFile, []byte(`{"msg": "token my-secret-value here"}`), 0600)).To(Succeed())
+			writeStub(mockDir, "leaktk", `echo '{"results": [{"secret": "my-secret-value"}]}'`)
+			writeStub(mockDir, "python3", `echo "my-secret-value"`)
+			writeStub(mockDir, "cp", `exit 1`)
+		})
+
+		It("should call fail_safe and overwrite the log file", func() {
+			output, exitCode := runSanitizer(scriptFile, logFile, mockDir)
+
+			Expect(exitCode).To(Equal(0))
+			Expect(output).To(ContainSubstring("Failed to create temporary log file"))
+			logContent, err := os.ReadFile(logFile) //nolint:gosec // test assertion
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(logContent)).To(ContainSubstring("Sanitization step failed"))
+		})
+	})
+
+	When("mv fails to replace the log file", func() {
+		BeforeEach(func() {
+			Expect(os.WriteFile(logFile, []byte(`{"msg": "token my-secret-value here"}`), 0600)).To(Succeed())
+			writeStub(mockDir, "leaktk", `echo '{"results": [{"secret": "my-secret-value"}]}'`)
+			writeStub(mockDir, "python3", `echo "my-secret-value"`)
+			writeStub(mockDir, "mv", `exit 1`)
+		})
+
+		It("should call fail_safe and overwrite the log file", func() {
+			output, exitCode := runSanitizer(scriptFile, logFile, mockDir)
+
+			Expect(exitCode).To(Equal(0))
+			Expect(output).To(ContainSubstring("Failed to replace log file with redacted version"))
+			logContent, err := os.ReadFile(logFile) //nolint:gosec // test assertion
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(logContent)).To(ContainSubstring("Sanitization step failed"))
+		})
+	})
+
+	When("secrets contain sed-special characters", func() {
+		BeforeEach(func() {
+			Expect(os.WriteFile(logFile, []byte(`{"msg": "token my.secret*value[0]|$x\y^(a+b?c{1}) here"}`), 0600)).To(Succeed())
+			writeStub(mockDir, "leaktk", `echo '{"results": [{"secret": "my.secret*value[0]|$x\\y^(a+b?c{1})"}]}'`)
+			writeStub(mockDir, "python3", `printf 'my.secret*value[0]|$x\\y^(a+b?c{1})\n'`)
+		})
+
+		It("should correctly redact secrets with regex metacharacters", func() {
+			output, exitCode := runSanitizer(scriptFile, logFile, mockDir)
+
+			Expect(exitCode).To(Equal(0))
+			Expect(output).To(ContainSubstring("Log sanitization complete"))
+			logContent, err := os.ReadFile(logFile) //nolint:gosec // test assertion
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(logContent)).To(Equal(`{"msg": "token **REDACTED** here"}`))
+			Expect(string(logContent)).NotTo(ContainSubstring("my.secret*value[0]|$x\\y^(a+b?c{1})"))
+		})
+	})
+})

--- a/internal/tekton/pipeline_run_builder.go
+++ b/internal/tekton/pipeline_run_builder.go
@@ -15,6 +15,7 @@
 package tekton
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -35,6 +36,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+//go:embed log_sanitizer.sh
+var logSanitizerScript string
 
 type PipelineRunBuilder struct {
 	err         *multierror.Error
@@ -102,6 +106,10 @@ func NewPipelineRunBuilder(name, namespace string) *PipelineRunBuilder {
 	renovateImageURL := os.Getenv(mmconst.RenovateImageEnvName)
 	if renovateImageURL == "" {
 		renovateImageURL = mmconst.DefaultRenovateImageURL
+	}
+	leaktkImageURL := os.Getenv(mmconst.LeakTKImageEnvName)
+	if leaktkImageURL == "" {
+		leaktkImageURL = mmconst.DefaultLeakTKImageURL
 	}
 	return &PipelineRunBuilder{
 		pipelineRun: &tektonv1.PipelineRun{
@@ -236,6 +244,33 @@ func NewPipelineRunBuilder(name, namespace string) *PipelineRunBuilder {
 												{
 													Name:  "RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS",
 													Value: "7",
+												},
+											},
+										},
+										{
+											Name:  "log-sanitizer",
+											Image: leaktkImageURL,
+											Env: []corev1.EnvVar{
+												{
+													Name:  "HOME",
+													Value: "/tmp",
+												},
+											},
+											Script: logSanitizerScript,
+											SecurityContext: &corev1.SecurityContext{
+												Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+												RunAsNonRoot:             ptr.To(true),
+												RunAsUser:                &normalUser,
+												AllowPrivilegeEscalation: ptr.To(false),
+											},
+											ComputeResources: corev1.ResourceRequirements{
+												Requests: corev1.ResourceList{
+													"cpu":    resource.MustParse("100m"),
+													"memory": resource.MustParse("256Mi"),
+												},
+												Limits: corev1.ResourceList{
+													"cpu":    resource.MustParse("100m"),
+													"memory": resource.MustParse("256Mi"),
 												},
 											},
 										},

--- a/internal/tekton/pipeline_run_builder_test.go
+++ b/internal/tekton/pipeline_run_builder_test.go
@@ -19,11 +19,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	. "github.com/konflux-ci/mintmaker/internal/constant"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("PipelineRun builder", func() {
@@ -437,6 +439,59 @@ var _ = Describe("PipelineRun builder", func() {
 					}
 				}
 			}
+		})
+	})
+
+	When("log-sanitizer step is created", func() {
+		It("should include a log-sanitizer step after the renovate step", func() {
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
+			steps := task.TaskSpec.Steps
+
+			Expect(steps).To(HaveLen(4))
+			Expect(steps[2].Name).To(Equal("renovate"))
+			Expect(steps[3].Name).To(Equal("log-sanitizer"))
+		})
+
+		It("should use the default leaktk image", func() {
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
+			logSanitizerStep := task.TaskSpec.Steps[3]
+
+			Expect(logSanitizerStep.Image).To(Equal(DefaultLeakTKImageURL))
+		})
+
+		It("should use LEAKTK_IMAGE env var when set", func() {
+			GinkgoT().Setenv("LEAKTK_IMAGE", "custom-registry.io/leaktk:v1.0")
+
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
+			logSanitizerStep := task.TaskSpec.Steps[3]
+
+			Expect(logSanitizerStep.Image).To(Equal("custom-registry.io/leaktk:v1.0"))
+		})
+
+		It("should set proper security context", func() {
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
+			logSanitizerStep := task.TaskSpec.Steps[3]
+
+			Expect(logSanitizerStep.SecurityContext).ToNot(BeNil())
+			Expect(logSanitizerStep.SecurityContext.RunAsNonRoot).To(Equal(ptr.To(true)))
+			Expect(logSanitizerStep.SecurityContext.AllowPrivilegeEscalation).To(Equal(ptr.To(false)))
+			Expect(logSanitizerStep.SecurityContext.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
+		})
+
+		It("should place log-sanitizer before log-analyzer when WithKiteIntegration is used", func() {
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			builder.WithKiteIntegration("https://kite.example.com")
+
+			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
+			steps := task.TaskSpec.Steps
+
+			Expect(steps).To(HaveLen(5))
+			Expect(steps[3].Name).To(Equal("log-sanitizer"))
+			Expect(steps[4].Name).To(Equal("log-analyzer"))
 		})
 	})
 


### PR DESCRIPTION
This commmit adds a new step in the MintMaker pipelinerun, to sanitize renovate-step logs.

In order to integrate MM with the Konflux UI, we will give read-permission to all logged users. Since the logs of all components lie in our namespace, all users will have access to the logs of all components.

If a credential were leaked in the logs, the wide access would make it severe. To prevent that, this commmit adds a step to sanitize the logs with leaktk, before they are persisted.

### Testing remarks

I tested manually that the script works as intended, and that the container that is created is able to run it.