### PR TITLE
fix: re-read renovate-config ConfigMap on each call (#544)

### DIFF
--- a/internal/component/base/base.go
+++ b/internal/component/base/base.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,11 +29,6 @@ import (
 	logger "sigs.k8s.io/controller-runtime/pkg/log"
 
 	bslices "github.com/konflux-ci/mintmaker/internal/slices"
-)
-
-var (
-	renovateBaseConfig      map[string]interface{}
-	renovateBaseConfigMutex sync.RWMutex
 )
 
 type BaseComponent struct {
@@ -128,14 +122,12 @@ func (c *BaseComponent) GetHostRules(ctx context.Context, registrySecret *corev1
 	return hostRules, nil
 }
 
+// GetRenovateBaseConfig reads the renovate-config ConfigMap fresh on every call.
+// The ConfigMap is fetched with an uncached client, so a change to it takes
+// effect on the next call without requiring a controller restart. It must not be
+// cached: a process-lifetime cache silently propagates stale config (e.g. a
+// changed GOPROXY) into every generated config.js until the pod is restarted.
 func (c *BaseComponent) GetRenovateBaseConfig(ctx context.Context, client client.Client) (map[string]interface{}, error) {
-	renovateBaseConfigMutex.RLock()
-	if renovateBaseConfig != nil {
-		defer renovateBaseConfigMutex.RUnlock()
-		return renovateBaseConfig, nil
-	}
-	renovateBaseConfigMutex.RUnlock()
-
 	baseConfig := corev1.ConfigMap{}
 	configmapKey := types.NamespacedName{Namespace: "mintmaker", Name: "renovate-config"}
 	if err := client.Get(ctx, configmapKey, &baseConfig); err != nil {
@@ -155,9 +147,6 @@ func (c *BaseComponent) GetRenovateBaseConfig(ctx context.Context, client client
 		config[k] = v
 	}
 
-	renovateBaseConfigMutex.Lock()
-	renovateBaseConfig = config
-	renovateBaseConfigMutex.Unlock()
 	return config, nil
 }
 

--- a/internal/component/base/base_test.go
+++ b/internal/component/base/base_test.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func renovateConfigMap(goproxy string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "renovate-config", Namespace: "mintmaker"},
+		Data: map[string]string{
+			"renovate.json":    `{"dryRun": "full"}`,
+			"self_hosted.json": `{"GOPROXY": "` + goproxy + `"}`,
+		},
+	}
+}
+
+// TestGetRenovateBaseConfigReflectsConfigMapChanges verifies that a change to the
+// renovate-config ConfigMap is picked up on the next call, without requiring a
+// controller restart (issue #544). It fails if GetRenovateBaseConfig caches the
+// config for the process lifetime.
+func TestGetRenovateBaseConfigReflectsConfigMapChanges(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(renovateConfigMap("https://proxy.internal/old")).
+		Build()
+
+	c := &BaseComponent{}
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: "mintmaker", Name: "renovate-config"}
+
+	config, err := c.GetRenovateBaseConfig(ctx, cl)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := config["GOPROXY"]; got != "https://proxy.internal/old" {
+		t.Fatalf("expected initial GOPROXY %q, got %v", "https://proxy.internal/old", got)
+	}
+
+	// Simulate an operator editing the ConfigMap (e.g. changing GOPROXY).
+	live := &corev1.ConfigMap{}
+	if err := cl.Get(ctx, key, live); err != nil {
+		t.Fatalf("failed to fetch configmap: %v", err)
+	}
+	live.Data["self_hosted.json"] = `{"GOPROXY": "https://proxy.internal/new"}`
+	if err := cl.Update(ctx, live); err != nil {
+		t.Fatalf("failed to update configmap: %v", err)
+	}
+
+	config, err = c.GetRenovateBaseConfig(ctx, cl)
+	if err != nil {
+		t.Fatalf("unexpected error on re-read: %v", err)
+	}
+	if got := config["GOPROXY"]; got != "https://proxy.internal/new" {
+		t.Fatalf("GetRenovateBaseConfig returned stale config after ConfigMap change: GOPROXY=%v, want %q", got, "https://proxy.internal/new")
+	}
+}


### PR DESCRIPTION
## Summary

- `GetRenovateBaseConfig` cached the `renovate-config` ConfigMap in a process-lifetime, package-level singleton (`renovateBaseConfig`) and never invalidated it. Once read, any later edit to the ConfigMap was ignored until the controller pod was restarted.
- ConfigMaps are deliberately excluded from the controller cache (`DisableFor` in `cmd/manager/main.go`), so no informer exists that could ever trigger a reload, and there was no TTL or reset path.
- Real production impact (reported in #544): a changed `GOPROXY` in `self_hosted.json` was never picked up, so generated `config.js` kept hammering `proxy.golang.org`; Renovate runs took 50+ minutes until `oc rollout restart`.

## Fix

- Drop the singleton (and its mutex) and re-read the ConfigMap on every call. `client.Get` is already a direct, uncached read whose cost is bounded by reconcile frequency, so a ConfigMap edit now takes effect on the next call without a restart.
- With no shared mutable state the function is inherently race-free, so `sync` is no longer needed.
- This matches the repo convention that ConfigMaps are fetched uncached (AGENTS.md).

## Changes

- `internal/component/base/base.go`: remove the `renovateBaseConfig`/`renovateBaseConfigMutex` package-level cache and the read short-circuit / write-back in `GetRenovateBaseConfig`; the ConfigMap is now read fresh each call. Drop the now-unused `sync` import.
- `internal/component/base/base_test.go`: add `TestGetRenovateBaseConfigReflectsConfigMapChanges`, which uses a fake client to assert that an update to the `renovate-config` ConfigMap is reflected by the next `GetRenovateBaseConfig` call (fails against the previous cached implementation).

`go build ./...`, `go vet ./internal/component/...`, and the new test all pass.

Fixes #544