### PR TITLE
chore: add golangci-lint and fix reported issues

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,13 +8,9 @@ on:
       - synchronize
       - reopened
 jobs:
-  go:
-    name: Check sources
+  go-lint:
+    name: Lint Go
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    env:
-      OPERATOR_SDK_VERSION: v1.39.1
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -24,27 +20,6 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-      - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: cache-operator-sdk
-        with:
-          path: ~/cache
-          key: operator-sdk-${{ env.OPERATOR_SDK_VERSION }}
-      - name: Download Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-        if: steps.cache-operator-sdk.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/cache
-          wget https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64 -O ~/cache/operator-sdk-${OPERATOR_SDK_VERSION} > /dev/null
-          chmod +x ~/cache/operator-sdk-${OPERATOR_SDK_VERSION}
-      - name: Install Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-        run: |
-          mkdir -p ~/bin
-          cp ~/cache/operator-sdk-${OPERATOR_SDK_VERSION} ~/bin/operator-sdk
-          echo "$HOME/bin" >> $GITHUB_PATH
-      - name: Regenerate executables with current environment packages
-        run: |
-          rm -f bin/kustomize bin/controller-gen
-          make kustomize controller-gen
       - name: Cache go modules
         id: cache-mod
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -59,29 +34,29 @@ jobs:
       - name: Check go mod status
         run: |
           go mod tidy
-          if [[ ! -z $(git status ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen' -s) ]]
+          if [[ ! -z $(git status -s) ]]
           then
             echo "Go mod state is not clean:"
-            git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
+            git --no-pager diff
             exit 1
           fi
       - name: Check format
         run: |
           make fmt
-          if [[ ! -z $(git status ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen' -s) ]]
+          if [[ ! -z $(git status -s) ]]
           then
             echo "Some files are not properly formatted."
             echo "Please run 'make fmt' and amend your commit."
-            git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
+            git --no-pager diff
             exit 1
           fi
       - name: Check manifests
         run: |
           make generate manifests
-          if [[ ! -z $(git status ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen' -s) ]]
+          if [[ ! -z $(git status -s) ]]
           then
             echo "Generated sources are not up to date:"
-            git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
+            git --no-pager diff
             exit 1
           fi
       - name: Check RBAC wildcards
@@ -90,17 +65,18 @@ jobs:
             echo "RBAC files contain wildcards (*)"
             exit 1
           fi
-      - name: Run Go Tests
-        run: make test
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        with:
-          use_oidc: true
-          flags: unit-tests
-          files: cover.out
-          fail_ci_if_error: false
-      - name: Ensure make build succeeds
-        run: make build
+      - name: Run golangci-lint
+        run: make lint
+
+  markdown-lint:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run markdownlint
+        run: npx --yes markdownlint-cli@0.49.0 --config .markdownlint.json '**/*.md'
 
   kube-linter:
     name: Lint Kubernetes manifests
@@ -132,3 +108,41 @@ jobs:
             echo "::warning file=AGENTS.md::AGENTS.md has ${lines} lines (max 300)."
             exit 1
           fi
+
+  go-test:
+    name: Test Go
+    needs: go-lint
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+      - name: Cache go modules
+        id: cache-mod
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Download dependencies
+        run: go mod download
+        if: steps.cache-mod.outputs.cache-hit != 'true'
+      - name: Run Go Tests
+        run: make test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: cover.out
+          fail_ci_if_error: false
+      - name: Ensure make build succeeds
+        run: make build

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,10 @@
+version: "2"
+
+run:
+  timeout: 5m
+  relative-path-mode: gomod
+
+linters:
+  default: standard
+  enable:
+    - gosec

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ repos:
     rev: v0.49.0
     hooks:
       - id: markdownlint
+        # ava@8 (dev dep of markdownlint-cli) rejects Node 25; pin an LTS version.
+        language_version: 24.12.0
         args: [--config, .markdownlint.json]
 
   - repo: local
@@ -14,6 +16,16 @@ repos:
         language: system
         files: ^AGENTS\.md$
         pass_filenames: false
+
+  - repo: local
+    hooks:
+      - id: make-lint
+        name: make lint
+        entry: make
+        args: [lint]
+        language: system
+        pass_filenames: false
+        always_run: true
 
   - repo: local
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Run from the repository root. See `make help` for every target.
 | ------- | ------------ |
 | `make fmt` | Runs `go fmt ./...` on all packages. CI fails if code is not formatted. |
 | `make vet` | Runs `go vet ./...` for static analysis. |
+| `make lint` | Runs `golangci-lint` using the `.golangci.yaml` config file on the repository. |
 | `make generate` | Regenerates DeepCopy methods (`controller-gen object`); needed after API type changes. Output includes `zz_generated.deepcopy.go` files — do not edit. |
 | `make manifests` | Regenerates CRD YAML under `config/crd/bases/` and RBAC under `config/rbac/` from kubebuilder markers and API types — do not edit generated YAML files. |
 | `make test` | Runs `manifests`, `generate`, `fmt`, `vet`, then unit and integration tests with **envtest** (downloads kubebuilder assets for `ENVTEST_K8S_VERSION` in the Makefile). Produces `cover.out`. |
@@ -31,7 +32,7 @@ Run from the repository root. See `make help` for every target.
 ## Conventions
 
 - **Edits**: Match existing patterns in the package you edit (Apache 2.0 headers, logging, naming of variables); minimize diff scope.
-- **Formatting**: Keep Go gofmt clean (`go fmt ./...`); for Markdown, respect `markdownlint` (see `.markdownlint.json`).
+- **Formatting**: Keep Go gofmt clean (`go fmt ./...`); for Markdown, respect `markdownlint` (see `.markdownlint.json`). Keep `golangci-lint` clean (run `make lint` after changes).
 - **Tests**: Add or update `*_test.go` alongside any new behavior or behavior change. Run `make test` before committing.
 - **Test style**: Follow the style used in the edited package. If the package has a `suite_test.go`, add Ginkgo/Gomega specs in separate `*_test.go` files (keep `suite_test.go` as runner/shared setup). Otherwise use standard Go table-driven tests.
 - **API / CRD changes**: After edits under `api/v1alpha1/`, run `make generate manifests` and commit generated DeepCopy, CRD (`config/crd/bases/`), and RBAC YAML. Never edit those files.

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -232,7 +232,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,7 +18,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"net/http"
-	_ "net/http/pprof"
+	_ "net/http/pprof" //nolint:gosec // profiling enabled only on localhost when ENABLE_PROFILING=true
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -44,7 +44,7 @@ import (
 
 	mmv1alpha1 "github.com/konflux-ci/mintmaker/api/v1alpha1"
 	"github.com/konflux-ci/mintmaker/internal/component"
-	. "github.com/konflux-ci/mintmaker/internal/constant"
+	mmconst "github.com/konflux-ci/mintmaker/internal/constant"
 	"github.com/konflux-ci/mintmaker/internal/controller"
 	mintmakermetrics "github.com/konflux-ci/mintmaker/internal/metrics"
 	// +kubebuilder:scaffold:imports
@@ -169,19 +169,19 @@ func main() {
 			ByObject: map[client.Object]cache.ByObject{
 				&mmv1alpha1.DependencyUpdateCheck{}: {
 					Namespaces: map[string]cache.Config{
-						MintMakerNamespaceName: {},
+						mmconst.MintMakerNamespaceName: {},
 					},
 					Transform: cache.TransformStripManagedFields(),
 				},
 				&corev1.Event{}: {
 					Namespaces: map[string]cache.Config{
-						MintMakerNamespaceName: {},
+						mmconst.MintMakerNamespaceName: {},
 					},
 					Transform: cache.TransformStripManagedFields(),
 				},
 				&tektonv1.PipelineRun{}: {
 					Namespaces: map[string]cache.Config{
-						MintMakerNamespaceName: {},
+						mmconst.MintMakerNamespaceName: {},
 					},
 					Transform: cache.TransformStripManagedFields(),
 				},
@@ -220,7 +220,7 @@ func main() {
 				addr = "127.0.0.1" + pprofAddr
 			}
 			setupLog.Info("starting pprof server", "address", addr)
-			if err := http.ListenAndServe(addr, nil); err != nil {
+			if err := http.ListenAndServe(addr, nil); err != nil { //nolint:gosec // localhost-only debug server gated by ENABLE_PROFILING
 				setupLog.Error(err, "pprof server failed")
 			}
 		}()

--- a/cmd/osv-generator/main.go
+++ b/cmd/osv-generator/main.go
@@ -31,7 +31,7 @@ func main() {
 	days := flag.Int("days", 120, "Only advisories created in the last X days are included")
 
 	flag.Parse()
-	err := os.MkdirAll(*destDir, 0755)
+	err := os.MkdirAll(*destDir, 0755) //nolint:gosec // need "other" permissions for the downloader to work
 	if err != nil {
 		fmt.Println("failed to create destination path: ", err)
 		os.Exit(1)
@@ -43,12 +43,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	osv_generator.GenerateOSV(filepath.Join(*destDir, *containerFilename), true, *days)
+	err = osv_generator.GenerateOSV(filepath.Join(*destDir, *containerFilename), true, *days)
 	if err != nil {
 		fmt.Println("Generating the container OSV database has failed: ", err)
 		os.Exit(1)
 	}
-	osv_generator.GenerateOSV(filepath.Join(*destDir, *rpmFilename), false, *days)
+	err = osv_generator.GenerateOSV(filepath.Join(*destDir, *rpmFilename), false, *days)
 	if err != nil {
 		fmt.Println("Generating the RPM OSV database has failed: ", err)
 		os.Exit(1)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,12 +89,12 @@ make docker-build docker-push IMG=<registry>/mintmaker:<tag>
 make test-e2e
 ```
 
-CI (`[.github/workflows/pr.yml](../.github/workflows/pr.yml)`) also runs: `go mod tidy` check, `make fmt`, `make generate manifests`, RBAC wildcard check, `make test`, `make build`, kube-linter on `config/`.
+CI (`[.github/workflows/pr.yml](../.github/workflows/pr.yml)`) runs the `Lint` job first (go mod tidy, `make fmt`, `make generate manifests`, RBAC wildcard check, `make lint`, markdownlint, kube-linter), then `Test Go` (`make test`, `make build`, Codecov) only after lint passes. The `Agent` job checks AGENTS.md line count in parallel.
 
 ## Before opening a pull request
 
 ```sh
-make fmt generate manifests test build
+make fmt generate manifests lint test build
 ```
 
 We welcome contributions via pull requests and issues. Maintainers: [.github/CODEOWNERS](../.github/CODEOWNERS) (`@konflux-ci/mintmaker-maintainers`).

--- a/internal/component/base/base.go
+++ b/internal/component/base/base.go
@@ -20,12 +20,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logger "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -236,7 +236,7 @@ func (c *BaseComponent) GetRPMActivationKey(ctx context.Context, k8sClient clien
 		componentRepoParts := strings.Split(c.Repository, "/")
 
 		// find wildcard repositories
-		wildcardRepos := slices.Filter(nil, secretRepositories, func(s string) bool { return strings.HasSuffix(s, "*") })
+		wildcardRepos := bslices.Filter(secretRepositories, func(s string) bool { return strings.HasSuffix(s, "*") })
 
 		for _, repo := range wildcardRepos {
 			i := bslices.Intersection(componentRepoParts, strings.Split(strings.TrimSuffix(repo, "*"), "/"))

--- a/internal/component/forgejo/forgejo.go
+++ b/internal/component/forgejo/forgejo.go
@@ -19,11 +19,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	gitea "code.gitea.io/sdk/gitea"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
@@ -154,7 +154,7 @@ func (c *Component) lookupSecret() (*corev1.Secret, error) {
 		componentRepoParts := strings.Split(c.Repository, "/")
 
 		// find wildcard repositories
-		wildcardRepos := slices.Filter(nil, secretRepositories, func(s string) bool { return strings.HasSuffix(s, "*") })
+		wildcardRepos := bslices.Filter(secretRepositories, func(s string) bool { return strings.HasSuffix(s, "*") })
 
 		for _, repo := range wildcardRepos {
 			i := bslices.Intersection(componentRepoParts, strings.Split(strings.TrimSuffix(repo, "*"), "/"))

--- a/internal/component/github/github.go
+++ b/internal/component/github/github.go
@@ -262,7 +262,7 @@ func (c *Component) fetchAppInstallations() ([]AppInstallation, error) {
 	for {
 		installations, resp, err := client.Apps.ListInstallations(context.Background(), &opt.ListOptions)
 		if err != nil {
-			if resp != nil && resp.Response != nil && resp.Response.StatusCode != 0 {
+			if resp != nil && resp.Response != nil && resp.StatusCode != 0 {
 				switch resp.StatusCode {
 				case 401:
 					return nil, fmt.Errorf("GitHub Application private key does not match Application ID")

--- a/internal/component/gitlab/gitlab.go
+++ b/internal/component/gitlab/gitlab.go
@@ -19,11 +19,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appstudiov1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
@@ -157,7 +157,7 @@ func (c *Component) lookupSecret() (*corev1.Secret, error) {
 		componentRepoParts := strings.Split(c.Repository, "/")
 
 		// find wildcard repositories
-		wildcardRepos := slices.Filter(nil, secretRepositories, func(s string) bool { return strings.HasSuffix(s, "*") })
+		wildcardRepos := bslices.Filter(secretRepositories, func(s string) bool { return strings.HasSuffix(s, "*") })
 
 		for _, repo := range wildcardRepos {
 			i := bslices.Intersection(componentRepoParts, strings.Split(strings.TrimSuffix(repo, "*"), "/"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,7 +141,7 @@ func defaultConfig() *Config {
 func load(path string) *Config {
 	log := ctrllog.Log.WithName("config")
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // path is the operator configuration file location
 	if err != nil {
 		if os.IsNotExist(err) {
 			log.Info("config file not found, using defaults", "path", path)

--- a/internal/constant/constants.go
+++ b/internal/constant/constants.go
@@ -22,7 +22,7 @@ const (
 	// Mintmaker can be disabled by disabled annotation in component
 	MintMakerDisabledAnnotationName = "mintmaker.appstudio.redhat.com/disabled"
 	// Label for the Kite token secret, used to find the secret in the namespace
-	KiteTokenSecretLabel = "mintmaker.appstudio.redhat.com/kite-token"
+	KiteTokenSecretLabel = "mintmaker.appstudio.redhat.com/kite-token" //nolint:gosec // label name, not a credential
 
 	// Label storing a truncated SHA256 hash of host/repository@branch.
 	// Used to find active PipelineRuns for a given repo+branch combination.

--- a/internal/controller/dependencyupdatecheck_controller.go
+++ b/internal/controller/dependencyupdatecheck_controller.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -41,7 +40,7 @@ import (
 	mmv1alpha1 "github.com/konflux-ci/mintmaker/api/v1alpha1"
 	"github.com/konflux-ci/mintmaker/internal/component"
 	"github.com/konflux-ci/mintmaker/internal/config"
-	. "github.com/konflux-ci/mintmaker/internal/constant"
+	mmconst "github.com/konflux-ci/mintmaker/internal/constant"
 	mintmakermetrics "github.com/konflux-ci/mintmaker/internal/metrics"
 	"github.com/konflux-ci/mintmaker/internal/tekton"
 	"github.com/konflux-ci/mintmaker/internal/utils"
@@ -56,7 +55,7 @@ type DependencyUpdateCheckReconciler struct {
 	NewGitComponent component.GitComponentFactory
 }
 
-func NewDependencyUpdateCheckReconciler(client client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder, newGitComponent component.GitComponentFactory) *DependencyUpdateCheckReconciler {
+func NewDependencyUpdateCheckReconciler(client client.Client, scheme *runtime.Scheme, newGitComponent component.GitComponentFactory) *DependencyUpdateCheckReconciler {
 	return &DependencyUpdateCheckReconciler{
 		Client:          client,
 		Scheme:          scheme,
@@ -71,7 +70,7 @@ func (r *DependencyUpdateCheckReconciler) getCAConfigMap(ctx context.Context) (*
 	configMapList := &corev1.ConfigMapList{}
 	labelSelector := client.MatchingLabels{"config.openshift.io/inject-trusted-cabundle": "true"}
 	listOptions := []client.ListOption{
-		client.InNamespace(MintMakerNamespaceName),
+		client.InNamespace(mmconst.MintMakerNamespaceName),
 		labelSelector,
 	}
 	err := r.Client.List(ctx, configMapList, listOptions...)
@@ -165,9 +164,9 @@ func (r *DependencyUpdateCheckReconciler) hasActivePipelineRun(ctx context.Conte
 
 	pipelineRuns := &tektonv1.PipelineRunList{}
 	listOpts := []client.ListOption{
-		client.InNamespace(MintMakerNamespaceName),
+		client.InNamespace(mmconst.MintMakerNamespaceName),
 		client.MatchingLabels{
-			MintMakerRepoBranchHashLabel: utils.RepoBranchHash(host, repository, branch),
+			mmconst.MintMakerRepoBranchHashLabel: utils.RepoBranchHash(host, repository, branch),
 		},
 	}
 
@@ -208,8 +207,7 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(ctx context.Context,
 	defer func() {
 		if len(resources) > 0 {
 			for _, resource := range resources {
-				// Ignore error
-				r.Client.Delete(ctx, resource)
+				_ = r.Client.Delete(ctx, resource)
 			}
 		}
 	}()
@@ -218,7 +216,7 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(ctx context.Context,
 	renovateSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: MintMakerNamespaceName,
+			Namespace: mmconst.MintMakerNamespaceName,
 		},
 		Type:       corev1.SecretTypeOpaque,
 		StringData: map[string]string{},
@@ -263,7 +261,7 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(ctx context.Context,
 	renovateConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: MintMakerNamespaceName,
+			Namespace: mmconst.MintMakerNamespaceName,
 		},
 		Data: map[string]string{
 			"config.js": renovateJsConfig,
@@ -284,7 +282,7 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(ctx context.Context,
 		rpmSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name + "-rpm-key",
-				Namespace: MintMakerNamespaceName,
+				Namespace: mmconst.MintMakerNamespaceName,
 			},
 			Type: corev1.SecretTypeOpaque,
 			StringData: map[string]string{
@@ -300,7 +298,7 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(ctx context.Context,
 	}
 
 	// Creating the pipelineRun definition
-	builder := tekton.NewPipelineRunBuilder(name, MintMakerNamespaceName).
+	builder := tekton.NewPipelineRunBuilder(name, mmconst.MintMakerNamespaceName).
 		WithLabels(map[string]string{
 			"mintmaker.appstudio.redhat.com/application":  comp.GetApplication(),
 			"mintmaker.appstudio.redhat.com/component":    comp.GetName(),
@@ -309,7 +307,7 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(ctx context.Context,
 			"mintmaker.appstudio.redhat.com/git-host":     comp.GetHost(),     // github.com, gitlab.com, gitlab.other.com
 			"mintmaker.appstudio.redhat.com/repository":   utils.NormalizeLabelValue(comp.GetRepository()),
 			"mintmaker.appstudio.redhat.com/branch":       utils.NormalizeLabelValue(currentBranch),
-			MintMakerRepoBranchHashLabel:                  utils.RepoBranchHash(comp.GetHost(), comp.GetRepository(), currentBranch),
+			mmconst.MintMakerRepoBranchHashLabel:          utils.RepoBranchHash(comp.GetHost(), comp.GetRepository(), currentBranch),
 		}).
 		WithTimeouts(nil)
 	builder.WithServiceAccount("mintmaker-controller-manager")
@@ -362,7 +360,7 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(ctx context.Context,
 			},
 		}
 		caConfigMapOpts := tekton.NewMountOptions().WithTaskName("build").WithStepNames([]string{"renovate"}).WithReadOnly(true)
-		builder.WithConfigMap(caConfigMap.ObjectMeta.Name, "/etc/pki/ca-trust/extracted/pem", caConfigMapItems, caConfigMapOpts)
+		builder.WithConfigMap(caConfigMap.Name, "/etc/pki/ca-trust/extracted/pem", caConfigMapItems, caConfigMapOpts)
 	}
 
 	if _, exists := renovateSecret.Data[corev1.DockerConfigJsonKey]; exists {
@@ -373,7 +371,7 @@ func (r *DependencyUpdateCheckReconciler) createPipelineRun(ctx context.Context,
 			},
 		}
 		secretOpts := tekton.NewMountOptions().WithTaskName("build").WithStepNames([]string{"renovate"}).WithReadOnly(true)
-		builder.WithSecret(renovateSecret.ObjectMeta.Name, "/home/renovate/.docker", secretItems, secretOpts)
+		builder.WithSecret(renovateSecret.Name, "/home/renovate/.docker", secretItems, secretOpts)
 	}
 
 	// Add Kite integration if enabled AND token is available
@@ -478,7 +476,7 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	// If the DependencyUpdateCheck has been handled before, skip it
-	if value, exists := dependencyupdatecheck.Annotations[MintMakerProcessedAnnotationName]; exists && value == "true" {
+	if value, exists := dependencyupdatecheck.Annotations[mmconst.MintMakerProcessedAnnotationName]; exists && value == "true" {
 		log.Info(fmt.Sprintf("DependencyUpdateCheck has been processed: %v", req.NamespacedName))
 		return ctrl.Result{}, nil
 	}
@@ -493,7 +491,7 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 	if dependencyupdatecheck.Annotations == nil {
 		dependencyupdatecheck.Annotations = map[string]string{}
 	}
-	dependencyupdatecheck.Annotations[MintMakerProcessedAnnotationName] = "true"
+	dependencyupdatecheck.Annotations[mmconst.MintMakerProcessedAnnotationName] = "true"
 
 	err = r.Client.Update(ctx, dependencyupdatecheck)
 	if err != nil {
@@ -523,7 +521,7 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 	// Filter out components which have mintmaker disabled
 	componentList := []appstudiov1alpha1.Component{}
 	for _, component := range gatheredComponents {
-		if value, exists := component.Annotations[MintMakerDisabledAnnotationName]; !exists || value != "true" {
+		if value, exists := component.Annotations[mmconst.MintMakerDisabledAnnotationName]; !exists || value != "true" {
 			componentList = append(componentList, component)
 		}
 	}
@@ -539,8 +537,8 @@ func (r *DependencyUpdateCheckReconciler) Reconcile(ctx context.Context, req ctr
 	if cfg := config.Get(); cfg.Kite.Enabled {
 		secretList := &corev1.SecretList{}
 		err := r.Client.List(ctx, secretList,
-			client.InNamespace(MintMakerNamespaceName),
-			client.MatchingLabels{KiteTokenSecretLabel: "true"},
+			client.InNamespace(mmconst.MintMakerNamespaceName),
+			client.MatchingLabels{mmconst.KiteTokenSecretLabel: "true"},
 		)
 		if err != nil {
 			log.Error(err, "Kite token secret lookup failed - skipping Kite integration")

--- a/internal/controller/event_controller.go
+++ b/internal/controller/event_controller.go
@@ -94,7 +94,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			}
 
 			var plr tektonv1.PipelineRun
-			if err := r.Client.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: plrName}, &plr); err != nil {
+			if err := r.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: plrName}, &plr); err != nil {
 				if apierrors.IsNotFound(err) {
 					// The PipelineRun is gone, we can't update it.
 					return
@@ -118,7 +118,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 	}()
 
-	if err := r.Client.Get(ctx, req.NamespacedName, &evt); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &evt); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -144,7 +144,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	podNamespace := evt.InvolvedObject.Namespace
 
 	// Get the actual corresponding Pod object for this event
-	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: podNamespace, Name: podName}, &pod); err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Namespace: podNamespace, Name: podName}, &pod); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Pod has gone, we can't proceed
 			return ctrl.Result{}, nil
@@ -175,7 +175,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	// Get the secret
 	var secret corev1.Secret
-	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: podNamespace, Name: secretName}, &secret); err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Namespace: podNamespace, Name: secretName}, &secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Secret doesn't exist, in theory this should not happen unless someone
 			// deleted the secret by manual, anyway we will ignore this
@@ -196,7 +196,7 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 		// Get the component
 		var comp appstudiov1alpha1.Component
-		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: componentNamespace, Name: componentName}, &comp); err != nil {
+		if err := r.Get(ctx, client.ObjectKey{Namespace: componentNamespace, Name: componentName}, &comp); err != nil {
 			if apierrors.IsNotFound(err) {
 				// Component has gone, we can't proceed
 				return ctrl.Result{}, nil

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -148,7 +148,7 @@ var _ = BeforeSuite(func() {
 		return newGitComponentForTest(ctx, comp, cl)
 	}
 
-	err = (NewDependencyUpdateCheckReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorderFor("DependencyUpdateCheckController"), factory)).SetupWithManager(k8sManager)
+	err = (NewDependencyUpdateCheckReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), factory)).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&PipelineRunReconciler{Client: k8sManager.GetClient(), Scheme: k8sManager.GetScheme()}).SetupWithManager(k8sManager)

--- a/internal/controller/suite_util_test.go
+++ b/internal/controller/suite_util_test.go
@@ -33,35 +33,6 @@ import (
 	. "github.com/konflux-ci/mintmaker/internal/constant"
 )
 
-var testPrivateKey = "-----BEGIN PRIVATE KEY-----\n" +
-	"MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC0lZNSLqX1n2aO" +
-	"loffn3rBL2+3Mm/GnjkWVQz76TS3KO7RSf4Det017H80XUumx3fT26rZ+wgpN8fi" +
-	"CCB2LWRlMVbQr2WxCl03l3/FmHRrbUPflbn5TWyxEUj4nST5BsIFkcXXVG2sHUuM" +
-	"+ZR5sbJadLLsj2Qn6Iy7zwV/pyDf89tZMXsTvO4SBhnYvitkDg6p3ar6uXMDd3aX" +
-	"Cwib8s/qJW7w7M/5duoVvtlBnsPpVjJvfmwOH2jzhzWOj0KaaS2Z+DIqnSyiU4Jd" +
-	"vvUlQLp3rmvTgf6R38P3phcLwb3gdu+9BqwP73vF9R52SXxfcFNRJ3cD9GdcYdL4" +
-	"/2hqqtknAgMBAAECggEAFLvfxbMpcZbdtZ1powQH73USL0c74jgkdytIvwZlpmoC" +
-	"vEZHQ1WwtGefq1QoQtFAMYj/3YtJwpcZp3AmGgDYOBjUI53KipXqt16jraegJlLN" +
-	"/4viEH0SmmSmVjU6G4WVHVfsDpnZBcakorO9Qm5j+1LO1a5uYiP8lKEOZpEP4JFI" +
-	"1T81LuyQDgsbZlmPEuxE0GSGkHKxT+b6VmvCvkN8gjUuYkHNNwd0lbqBvOvh9rSu" +
-	"2iSONFHIYJloC6e09+cDlM/DedwS3aOpaoOzq8HGeIZLCo1XoBlqWx+NyyXbDKaS" +
-	"eDAldq+4npEx58E4wt5Wy/FpBHInvOLXM6RQZn2n8QKBgQDv/oL4KlPvlaCV7qtK" +
-	"gBbKxLjk2EZGqAuAHaskMDTAsexyXUuzPEO2cNgPGVuiPpbYtg2LI5Wngan56f3O" +
-	"7b5SUykIa0DuvMgZyp80W5pCxfHROxUL6t9gyCaOwyl9ejvocF3H40JX56WT/DZC" +
-	"U0M5xiSODStYyQCzScGS4PVE7QKBgQDAoL3lqQE9obw4ipO0CKnRlU5zoitClj8L" +
-	"3CtkP/uoR/lHQvJlZz0xyhV2ansZxtPBdjB5u79q8wRV8HeTCGmZKuN5tfC7ZnH4" +
-	"TEaq1AjIIim2zfCJaLT1L+6jS5+MUWZPoDfWrHdGFYuPtN8FMqaojz7kI0p33uMm" +
-	"lff/fjVH4wKBgA5TWu4FWM1MWTGZ9Y+U5cdkxsSiRE+jaExVeQnH9t4pwLty5jnk" +
-	"twYE5mDAWr/sjISTGWvcy+oby1GnrgbUGjA/1osyG8Ykbq1bcvVlImgp+K1MoYz8" +
-	"kCjuyZ5r9+YNjdXqHy73WdZ1dWTIAVUkMzcXpMb18khydyA8ntltpDZhAoGAJJil" +
-	"W1OPg8kNfGR/iU24DbRjEj72HxFyautqZwJs6ly6NFq4uKEzlBkDmNrEBnKq2m98" +
-	"6DPOOyBua3FjFlEb1ti6HO5/DOt6raS4LE5aWMN8z1ky4Lg+4PI5UVbVug/g8zHK" +
-	"SgO8KVmAiU3grRkhZpbIaQl3ZWy4FSWa1zSAJOcCgYEA1IEZPnJDM8Hlqj/vZBRa" +
-	"t2/ZKaNf3Je64KElsfvQ/SoMmOPHkfFfJK3+GqQbsjQ6Jr4MwzjDia3GcIagui3t" +
-	"mvfkc6syo7pMwBIylWZVCIGtyW/CVPL8uMA+6yvgksEIeVL40DfO6cI5OH7kQp87" +
-	"t8RRiu3Z5nY3spNv38kAa9s=" +
-	"\n-----END PRIVATE KEY-----"
-
 func createNamespace(name string) {
 	namespace := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
@@ -154,36 +125,6 @@ func createSecret(resourceKey types.NamespacedName, secretType corev1.SecretType
 	getSecret(resourceKey)
 }
 
-func createSCMSecret(resourceKey types.NamespacedName, data map[string]string, secretType corev1.SecretType, annotations map[string]string) {
-	labels := map[string]string{
-		"appstudio.redhat.com/credentials": "scm",
-		"appstudio.redhat.com/scm.host":    "gitlab.com",
-	}
-	secret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Secret",
-		},
-		Type: secretType,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        resourceKey.Name,
-			Namespace:   resourceKey.Namespace,
-			Labels:      labels,
-			Annotations: annotations,
-		},
-		StringData: data,
-	}
-	if err := k8sClient.Create(ctx, secret); err != nil {
-		if !k8sErrors.IsAlreadyExists(err) {
-			Fail(err.Error())
-		}
-		deleteSecret(resourceKey)
-		Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
-	}
-
-	getSecret(resourceKey)
-}
-
 func deleteSecret(resourceKey types.NamespacedName) {
 	secret := &corev1.Secret{}
 	if err := k8sClient.Get(ctx, resourceKey, secret); err != nil {
@@ -209,48 +150,6 @@ func getSecret(resourceKey types.NamespacedName) *corev1.Secret {
 		return k8sClient.Get(ctx, resourceKey, secret)
 	}, timeout, interval).Should(Succeed())
 	return secret
-}
-
-func createConfigMap(resourceKey types.NamespacedName, data map[string]string) {
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceKey.Name,
-			Namespace: resourceKey.Namespace,
-		},
-		Data: data,
-	}
-	Expect(k8sClient.Create(ctx, configMap)).Should(Succeed())
-	getConfigMap(resourceKey)
-}
-
-func getConfigMap(resourceKey types.NamespacedName) *corev1.ConfigMap {
-	configMap := &corev1.ConfigMap{}
-	Eventually(func() bool {
-		if err := k8sClient.Get(ctx, resourceKey, configMap); err != nil {
-			return false
-		}
-		return true
-	}, timeout, interval).Should(BeTrue())
-	return configMap
-}
-
-func deleteConfigMap(resourceKey types.NamespacedName) {
-	configMap := &corev1.ConfigMap{}
-	if err := k8sClient.Get(ctx, resourceKey, configMap); err != nil {
-		if k8sErrors.IsNotFound(err) {
-			return
-		}
-		Fail(err.Error())
-	}
-	if err := k8sClient.Delete(ctx, configMap); err != nil {
-		if !k8sErrors.IsNotFound(err) {
-			Fail(err.Error())
-		}
-		return
-	}
-	Eventually(func() bool {
-		return k8sErrors.IsNotFound(k8sClient.Get(ctx, resourceKey, configMap))
-	}, timeout, interval).Should(BeTrue())
 }
 
 func createComponent(resourceKey types.NamespacedName, crdVersion, application, gitURL, gitRevision, gitSourceContext string) {
@@ -365,21 +264,6 @@ func deleteComponent(resourceKey types.NamespacedName) {
 	Eventually(func() bool {
 		return k8sErrors.IsNotFound(k8sClient.Get(ctx, resourceKey, component))
 	}, timeout, interval).Should(BeTrue())
-}
-
-func disableComponentMintmaker(resourceKey types.NamespacedName) {
-	component := &appstudiov1alpha1.Component{}
-	Expect(k8sClient.Get(ctx, resourceKey, component)).Should(Succeed())
-
-	if component.Annotations == nil {
-		component.Annotations = make(map[string]string)
-	}
-
-	component.Annotations[MintMakerDisabledAnnotationName] = "true"
-
-	Expect(k8sClient.Update(ctx, component)).Should(Succeed())
-
-	getComponent(resourceKey)
 }
 
 func createDependencyUpdateCheck(resourceKey types.NamespacedName, processed bool, namespaces []mmv1alpha1.NamespaceSpec) {

--- a/internal/tekton/pipeline_run_builder.go
+++ b/internal/tekton/pipeline_run_builder.go
@@ -19,19 +19,19 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 	"unicode"
 
 	"github.com/hashicorp/go-multierror"
-	. "github.com/konflux-ci/mintmaker/internal/constant"
+	mmconst "github.com/konflux-ci/mintmaker/internal/constant"
 	"github.com/konflux-ci/mintmaker/internal/utils"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -99,9 +99,9 @@ func (o *MountOptions) WithOptional(optional bool) *MountOptions {
 func NewPipelineRunBuilder(name, namespace string) *PipelineRunBuilder {
 	var rootUser int64 = 0
 	var normalUser int64 = 1001120000
-	renovateImageURL := os.Getenv(RenovateImageEnvName)
+	renovateImageURL := os.Getenv(mmconst.RenovateImageEnvName)
 	if renovateImageURL == "" {
-		renovateImageURL = DefaultRenovateImageURL
+		renovateImageURL = mmconst.DefaultRenovateImageURL
 	}
 	return &PipelineRunBuilder{
 		pipelineRun: &tektonv1.PipelineRun{
@@ -264,11 +264,11 @@ func (b *PipelineRunBuilder) Build() (*tektonv1.PipelineRun, error) {
 // WithAnnotations appends or updates annotations to the PipelineRun's metadata.
 // If the PipelineRun does not have existing annotations, it initializes them before adding.
 func (b *PipelineRunBuilder) WithAnnotations(annotations map[string]string) *PipelineRunBuilder {
-	if b.pipelineRun.ObjectMeta.Annotations == nil {
-		b.pipelineRun.ObjectMeta.Annotations = make(map[string]string)
+	if b.pipelineRun.Annotations == nil {
+		b.pipelineRun.Annotations = make(map[string]string)
 	}
 	for key, value := range annotations {
-		b.pipelineRun.ObjectMeta.Annotations[key] = value
+		b.pipelineRun.Annotations[key] = value
 	}
 	return b
 }
@@ -282,11 +282,11 @@ func (b *PipelineRunBuilder) WithFinalizer(finalizer string) *PipelineRunBuilder
 // WithLabels appends or updates labels to the PipelineRun's metadata.
 // If the PipelineRun does not have existing labels, it initializes them before adding.
 func (b *PipelineRunBuilder) WithLabels(labels map[string]string) *PipelineRunBuilder {
-	if b.pipelineRun.ObjectMeta.Labels == nil {
-		b.pipelineRun.ObjectMeta.Labels = make(map[string]string)
+	if b.pipelineRun.Labels == nil {
+		b.pipelineRun.Labels = make(map[string]string)
 	}
 	for key, value := range labels {
-		b.pipelineRun.ObjectMeta.Labels[key] = value
+		b.pipelineRun.Labels[key] = value
 	}
 	return b
 }
@@ -331,8 +331,8 @@ func (b *PipelineRunBuilder) WithConfigMap(name, mountPath string, items []corev
 					},
 				},
 			}
-			b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.TaskSpec.Volumes = append(
-				b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.TaskSpec.Volumes,
+			b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.Volumes = append(
+				b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.Volumes,
 				volume,
 			)
 
@@ -343,8 +343,8 @@ func (b *PipelineRunBuilder) WithConfigMap(name, mountPath string, items []corev
 				ReadOnly:  *opts.ReadOnly,
 			}
 
-			for j := range b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.TaskSpec.Steps {
-				step := &b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.TaskSpec.Steps[j]
+			for j := range b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.Steps {
+				step := &b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.Steps[j]
 				if len(opts.StepNames) == 0 || slices.Contains(opts.StepNames, step.Name) {
 					step.VolumeMounts = append(step.VolumeMounts, volumeMount)
 				}
@@ -390,8 +390,8 @@ func (b *PipelineRunBuilder) WithSecret(name, mountPath string, items []corev1.K
 					},
 				},
 			}
-			b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.TaskSpec.Volumes = append(
-				b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.TaskSpec.Volumes,
+			b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.Volumes = append(
+				b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.Volumes,
 				volume,
 			)
 
@@ -402,8 +402,8 @@ func (b *PipelineRunBuilder) WithSecret(name, mountPath string, items []corev1.K
 				ReadOnly:  *opts.ReadOnly,
 			}
 
-			for j := range b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.TaskSpec.Steps {
-				step := &b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.TaskSpec.Steps[j]
+			for j := range b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.Steps {
+				step := &b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.Steps[j]
 				if len(opts.StepNames) == 0 || slices.Contains(opts.StepNames, step.Name) {
 					step.VolumeMounts = append(step.VolumeMounts, volumeMount)
 				}
@@ -498,7 +498,7 @@ func (b *PipelineRunBuilder) WithKiteIntegration(kiteAPIURL string) *PipelineRun
 	// Find the build task and add log-analyzer step
 	for i, task := range b.pipelineRun.Spec.PipelineSpec.Tasks {
 		if task.Name == "build" && task.TaskSpec != nil {
-			steps := &b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.TaskSpec.Steps
+			steps := &b.pipelineRun.Spec.PipelineSpec.Tasks[i].TaskSpec.Steps
 			logAnalyzerStep := tektonv1.Step{
 				Name:   "log-analyzer",
 				Image:  "quay.io/konflux-ci/renovate-log-analyzer:latest",

--- a/internal/tekton/pipeline_run_builder_test.go
+++ b/internal/tekton/pipeline_run_builder_test.go
@@ -95,7 +95,7 @@ var _ = Describe("PipelineRun builder", func() {
 		})
 
 		It("should update existing annotations and add new ones", func() {
-			builder.pipelineRun.ObjectMeta.Annotations = map[string]string{
+			builder.pipelineRun.Annotations = map[string]string{
 				"annotation1": "oldValue1",
 				"annotation3": "value3",
 			}
@@ -124,7 +124,7 @@ var _ = Describe("PipelineRun builder", func() {
 		})
 
 		It("should append a new finalizer to the existing finalizers", func() {
-			builder.pipelineRun.ObjectMeta.Finalizers = []string{"existingFinalizer"}
+			builder.pipelineRun.Finalizers = []string{"existingFinalizer"}
 			builder.WithFinalizer("finalizer2")
 			Expect(builder.pipelineRun.ObjectMeta.Finalizers).To(ContainElements("existingFinalizer", "finalizer2"))
 		})
@@ -149,7 +149,7 @@ var _ = Describe("PipelineRun builder", func() {
 		})
 
 		It("should update existing labels and add new ones", func() {
-			builder.pipelineRun.ObjectMeta.Labels = map[string]string{
+			builder.pipelineRun.Labels = map[string]string{
 				"label1": "oldValue1",
 				"label3": "value3",
 			}
@@ -307,11 +307,11 @@ var _ = Describe("PipelineRun builder", func() {
 			builder.WithConfigMap("my-config", "/etc/config", nil, nil)
 
 			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
-			Expect(task.TaskSpec.TaskSpec.Volumes).To(HaveLen(1))
-			Expect(task.TaskSpec.TaskSpec.Volumes[0].Name).To(Equal("configmap-my-config"))
-			Expect(task.TaskSpec.TaskSpec.Volumes[0].VolumeSource.ConfigMap.Name).To(Equal("my-config"))
+			Expect(task.TaskSpec.Volumes).To(HaveLen(1))
+			Expect(task.TaskSpec.Volumes[0].Name).To(Equal("configmap-my-config"))
+			Expect(task.TaskSpec.Volumes[0].VolumeSource.ConfigMap.Name).To(Equal("my-config"))
 
-			for _, step := range task.TaskSpec.TaskSpec.Steps {
+			for _, step := range task.TaskSpec.Steps {
 				Expect(step.VolumeMounts).To(ContainElement(
 					HaveField("MountPath", "/etc/config"),
 				))
@@ -323,7 +323,7 @@ var _ = Describe("PipelineRun builder", func() {
 			builder.WithConfigMap("my-config", "/etc/config", nil, opts)
 
 			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
-			for _, step := range task.TaskSpec.TaskSpec.Steps {
+			for _, step := range task.TaskSpec.Steps {
 				if step.Name == "renovate" {
 					Expect(step.VolumeMounts).To(ContainElement(
 						HaveField("MountPath", "/etc/config"),
@@ -347,7 +347,7 @@ var _ = Describe("PipelineRun builder", func() {
 			builder.WithConfigMap("my-config", "/etc/config", items, nil)
 
 			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
-			Expect(task.TaskSpec.TaskSpec.Volumes[0].VolumeSource.ConfigMap.Items).To(Equal(items))
+			Expect(task.TaskSpec.Volumes[0].VolumeSource.ConfigMap.Items).To(Equal(items))
 		})
 
 		It("should set optional and default mode from MountOptions", func() {
@@ -361,15 +361,15 @@ var _ = Describe("PipelineRun builder", func() {
 			builder.WithConfigMap("my-config", "/etc/config", nil, opts)
 
 			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
-			Expect(*task.TaskSpec.TaskSpec.Volumes[0].VolumeSource.ConfigMap.Optional).To(BeTrue())
-			Expect(*task.TaskSpec.TaskSpec.Volumes[0].VolumeSource.ConfigMap.DefaultMode).To(Equal(mode))
+			Expect(*task.TaskSpec.Volumes[0].VolumeSource.ConfigMap.Optional).To(BeTrue())
+			Expect(*task.TaskSpec.Volumes[0].VolumeSource.ConfigMap.DefaultMode).To(Equal(mode))
 		})
 
 		It("should handle dots in configmap name", func() {
 			builder.WithConfigMap("my.dotted.config", "/etc/config", nil, nil)
 
 			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
-			Expect(task.TaskSpec.TaskSpec.Volumes[0].Name).To(Equal("configmap-my-dotted-config"))
+			Expect(task.TaskSpec.Volumes[0].Name).To(Equal("configmap-my-dotted-config"))
 		})
 	})
 
@@ -384,10 +384,10 @@ var _ = Describe("PipelineRun builder", func() {
 			builder.WithSecret("my-secret", "/etc/secret", nil, nil)
 
 			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
-			Expect(task.TaskSpec.TaskSpec.Volumes).To(HaveLen(1))
-			Expect(task.TaskSpec.TaskSpec.Volumes[0].VolumeSource.Secret.SecretName).To(Equal("my-secret"))
+			Expect(task.TaskSpec.Volumes).To(HaveLen(1))
+			Expect(task.TaskSpec.Volumes[0].VolumeSource.Secret.SecretName).To(Equal("my-secret"))
 
-			for _, step := range task.TaskSpec.TaskSpec.Steps {
+			for _, step := range task.TaskSpec.Steps {
 				Expect(step.VolumeMounts).To(ContainElement(
 					HaveField("MountPath", "/etc/secret"),
 				))
@@ -399,7 +399,7 @@ var _ = Describe("PipelineRun builder", func() {
 			builder.WithSecret("my-secret", "/etc/secret", nil, opts)
 
 			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
-			for _, step := range task.TaskSpec.TaskSpec.Steps {
+			for _, step := range task.TaskSpec.Steps {
 				if step.Name == "renovate" {
 					Expect(step.VolumeMounts).To(ContainElement(
 						HaveField("MountPath", "/etc/secret"),
@@ -421,8 +421,8 @@ var _ = Describe("PipelineRun builder", func() {
 			builder.WithSecret("my-secret", "/etc/secret2", nil, nil)
 
 			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
-			Expect(task.TaskSpec.TaskSpec.Volumes).To(HaveLen(2))
-			Expect(task.TaskSpec.TaskSpec.Volumes[0].Name).ToNot(Equal(task.TaskSpec.TaskSpec.Volumes[1].Name))
+			Expect(task.TaskSpec.Volumes).To(HaveLen(2))
+			Expect(task.TaskSpec.Volumes[0].Name).ToNot(Equal(task.TaskSpec.Volumes[1].Name))
 		})
 
 		It("should set read-only to false when specified", func() {
@@ -430,7 +430,7 @@ var _ = Describe("PipelineRun builder", func() {
 			builder.WithSecret("my-secret", "/etc/secret", nil, opts)
 
 			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
-			for _, step := range task.TaskSpec.TaskSpec.Steps {
+			for _, step := range task.TaskSpec.Steps {
 				for _, vm := range step.VolumeMounts {
 					if vm.MountPath == "/etc/secret" {
 						Expect(vm.ReadOnly).To(BeFalse())
@@ -446,7 +446,7 @@ var _ = Describe("PipelineRun builder", func() {
 			builder.WithKiteIntegration("https://kite.example.com")
 
 			task := builder.pipelineRun.Spec.PipelineSpec.Tasks[0]
-			steps := task.TaskSpec.TaskSpec.Steps
+			steps := task.TaskSpec.Steps
 			lastStep := steps[len(steps)-1]
 
 			Expect(lastStep.Name).To(Equal("log-analyzer"))

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -61,7 +61,7 @@ var _ = Describe("controller", Ordered, func() {
 			var projectimage = "example.com/mintmaker:v0.0.1"
 
 			By("building the manager(Operator) image")
-			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
+			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage)) //nolint:gosec // e2e test builds a local test image
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
@@ -75,7 +75,7 @@ var _ = Describe("controller", Ordered, func() {
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("deploying the controller-manager")
-			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
+			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage)) //nolint:gosec // e2e test deploys a local test image
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
@@ -102,7 +102,7 @@ var _ = Describe("controller", Ordered, func() {
 				ExpectWithOffset(2, controllerPodName).Should(ContainSubstring("controller-manager"))
 
 				// Validate pod status
-				cmd = exec.Command("kubectl", "get",
+				cmd = exec.Command("kubectl", "get", //nolint:gosec // e2e test inspects the deployed controller pod
 					"pods", controllerPodName, "-o", "jsonpath={.status.phase}",
 					"-n", namespace,
 				)

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -20,7 +20,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck // ginkgo dot import is conventional in specs
 )
 
 const (
@@ -39,7 +39,7 @@ func warnError(err error) {
 // InstallPrometheusOperator installs the prometheus Operator to be used to export the enabled metrics.
 func InstallPrometheusOperator() error {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.Command("kubectl", "create", "-f", url)
+	cmd := exec.Command("kubectl", "create", "-f", url) //nolint:gosec // test helper installs fixed upstream manifests
 	_, err := Run(cmd)
 	return err
 }
@@ -67,7 +67,7 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 // UninstallPrometheusOperator uninstalls the prometheus
 func UninstallPrometheusOperator() {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.Command("kubectl", "delete", "-f", url)
+	cmd := exec.Command("kubectl", "delete", "-f", url) //nolint:gosec // test helper uninstalls fixed upstream manifests
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
@@ -76,7 +76,7 @@ func UninstallPrometheusOperator() {
 // UninstallCertManager uninstalls the cert manager
 func UninstallCertManager() {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
-	cmd := exec.Command("kubectl", "delete", "-f", url)
+	cmd := exec.Command("kubectl", "delete", "-f", url) //nolint:gosec // test helper uninstalls fixed upstream manifests
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
@@ -85,7 +85,7 @@ func UninstallCertManager() {
 // InstallCertManager installs the cert manager bundle.
 func InstallCertManager() error {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
-	cmd := exec.Command("kubectl", "apply", "-f", url)
+	cmd := exec.Command("kubectl", "apply", "-f", url) //nolint:gosec // test helper installs fixed upstream manifests
 	if _, err := Run(cmd); err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func LoadImageToKindClusterWithName(name string) error {
 		cluster = v
 	}
 	kindOptions := []string{"load", "docker-image", name, "--name", cluster}
-	cmd := exec.Command("kind", kindOptions...)
+	cmd := exec.Command("kind", kindOptions...) //nolint:gosec // e2e test loads a local image into kind
 	_, err := Run(cmd)
 	return err
 }
@@ -133,6 +133,6 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }

--- a/tools/osv-downloader/download_osv.go
+++ b/tools/osv-downloader/download_osv.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/go-github/v82/github"
 )
@@ -45,17 +46,17 @@ func DownloadOsvDb(path string) error {
 
 func downloadFile(url string, filepath string) error {
 	fmt.Println("downloading osv-offline database")
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) //nolint:gosec // URL comes from the official renovatebot GitHub release
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
-	out, err := os.Create(filepath)
+	out, err := os.Create(filepath) //nolint:gosec // output path is constructed by the caller
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 
 	_, err = io.Copy(out, resp.Body)
 	return err
@@ -67,30 +68,48 @@ func unzipFile(archive_path string, destination string) error {
 	if err != nil {
 		return err
 	}
-	defer archive.Close()
+	defer func() { _ = archive.Close() }()
 
+	destination = filepath.Clean(destination)
 	for _, file := range archive.File {
-		filePath := filepath.Join(destination, file.Name)
+		filePath := filepath.Join(destination, file.Name) //nolint:gosec // zip entry paths are validated below
+		cleanPath := filepath.Clean(filePath)
+		// Guard against zip slip: reject entries whose resolved path escapes destination
+		// after Join+Clean, e.g. "../../etc/passwd" with destination "/tmp/osv-db" resolves
+		// to "/etc/passwd", which is not under "/tmp/osv-db/".
+		if !strings.HasPrefix(cleanPath, destination+string(os.PathSeparator)) && cleanPath != destination {
+			return fmt.Errorf("invalid file path in archive: %s", file.Name)
+		}
 		if file.FileInfo().IsDir() {
-			os.MkdirAll(filePath, os.ModePerm)
+			if err := os.MkdirAll(filePath, 0755); err != nil { //nolint:gosec // need "other" permissions for Tekton prepare-db step
+				return err
+			}
 			continue
 		}
-		if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil { //nolint:gosec // need "other" permissions for Tekton prepare-db step
 			return err
 		}
-		destFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+		destFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode()) //nolint:gosec // path validated above
 		if err != nil {
 			return err
 		}
 		fileInArchive, err := file.Open()
 		if err != nil {
+			_ = destFile.Close()
 			return err
 		}
-		if _, err := io.Copy(destFile, fileInArchive); err != nil {
+		if _, err := io.Copy(destFile, fileInArchive); err != nil { //nolint:gosec // archive is from the official renovatebot release
+			_ = destFile.Close()
+			_ = fileInArchive.Close()
 			return err
 		}
-		defer destFile.Close()
-		defer fileInArchive.Close()
+		if err := destFile.Close(); err != nil {
+			_ = fileInArchive.Close()
+			return err
+		}
+		if err := fileInArchive.Close(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/tools/osv-generator/cve_parser.go
+++ b/tools/osv-generator/cve_parser.go
@@ -31,18 +31,18 @@ func retryGet(url string, maxRetries int, backoff time.Duration) (string, error)
 	var lastErr error
 
 	for i := 0; i < maxRetries; i++ {
-		resp, err := http.Get(url)
+		resp, err := http.Get(url) //nolint:gosec,noctx // URL points to Red Hat security advisory data
 		if err == nil && resp.StatusCode == http.StatusOK {
-			defer resp.Body.Close()
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return "", fmt.Errorf("could not read response body: %w", err)
+			body, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				return "", fmt.Errorf("could not read response body: %w", readErr)
 			}
 			return string(body), nil
 		}
 
 		if resp != nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 		}
 		lastErr = err
 
@@ -120,11 +120,11 @@ func ConvertToOSV(vexData VEX, containerVulns bool) []OSV {
 
 // Save all CVEs to an OSV file
 func StoreToFile(filename string, convertedVulnerabilities []OSV) error {
-	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644) //nolint:gosec // output path is provided by the caller, needs "other" permissions
 	if err != nil {
 		return fmt.Errorf("error accessing file: %v", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	encoder := json.NewEncoder(file)
 
 	for _, v := range convertedVulnerabilities {

--- a/tools/osv-generator/generator.go
+++ b/tools/osv-generator/generator.go
@@ -29,12 +29,12 @@ const URL = "https://security.access.redhat.com/data/csaf/v2/advisories"
 // within the specified number of days from the current time. The advisory
 // filenames in releases.csv are sorted by released date, newest first.
 func getAdvisoryListByReleases(days int) ([]string, error) {
-	response, err := http.Get(fmt.Sprintf("%s/%s", URL, "releases.csv"))
+	response, err := http.Get(fmt.Sprintf("%s/%s", URL, "releases.csv")) //nolint:gosec,noctx // fixed Red Hat security advisory URL
 	if err != nil {
 		fmt.Println("Error downloading file:", err)
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 
 	// Load all advisories from the document
 	csvReader := csv.NewReader(response.Body)
@@ -69,12 +69,12 @@ func getAdvisoryListByReleases(days int) ([]string, error) {
 
 // Get list of new advisories sorted by name, returns maximum of `limit` advisories
 func getAdvisoryListByModified(limit int) ([]string, error) {
-	response, err := http.Get(fmt.Sprintf("%s/%s", URL, "changes.csv"))
+	response, err := http.Get(fmt.Sprintf("%s/%s", URL, "changes.csv")) //nolint:gosec,noctx // fixed Red Hat security advisory URL
 	if err != nil {
 		fmt.Println("Error downloading file:", err)
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 
 	// Load all advisories from the document
 	csvReader := csv.NewReader(response.Body)

--- a/tools/osv-generator/generator_test.go
+++ b/tools/osv-generator/generator_test.go
@@ -115,7 +115,7 @@ func TestGenerateOSVRPMs(t *testing.T) {
 
 	// Create a test file
 	err := GenerateOSV("testfile", false, 100000)
-	defer os.Remove("testfile")
+	defer func() { _ = os.Remove("testfile") }()
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -204,7 +204,7 @@ func TestGenerateOSVContainers(t *testing.T) {
 
 	// Create a test file
 	err := GenerateOSV("testfile", true, 100000)
-	defer os.Remove("testfile")
+	defer func() { _ = os.Remove("testfile") }()
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}


### PR DESCRIPTION
Adds [golangci-lint](https://golangci-lint.run/) to the repo. Contributors can now run `make lint` locally against a shared config. The linters are now also part of a pre-commit config and a CI workflow.

- **Config** (`.golangci.yaml`): standard linters + `gosec`
- **Makefile**: pin golangci-lint **v2.12.2** (v1.59.1 fails to build on Go 1.26)
- **Docs**: document `make lint` in `AGENTS.md` and document additional linters in CI in `contributing.md`
- **Code**: fix all current lint findings — mostly style/cleanup (dot imports, unused helpers/params in suit test file, embedded metadata fields, defer error handling) plus a few security-minded changes (`gosec` in osv-downloader zip extraction; `nolint` with rationale where behavior is intentional)

No functional behavior changes intended beyond the osv-downloader zip path validation (errors were not read from the function outputs - that is fixed now).