### PR TITLE
Increase workspace volume size to 5 Gi

### DIFF
--- a/.tekton/mintmaker-pull-request.yaml
+++ b/.tekton/mintmaker-pull-request.yaml
@@ -556,7 +556,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 1Gi
+            storage: 5Gi
       status: {}
   - name: git-auth
     secret:

--- a/.tekton/mintmaker-push.yaml
+++ b/.tekton/mintmaker-push.yaml
@@ -542,7 +542,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 1Gi
+            storage: 5Gi
       status: {}
   - name: git-auth
     secret:


### PR DESCRIPTION
https://github.com/konflux-ci/mintmaker/pull/541 build is failing with 
```
time="2026-06-29T11:38:55Z" level=info msg="buildah [stderr] cmd/osv-generator/main.go:23:2: write /cachi2/output/deps/gomod/d0/d0813beaa10d973559dfbf4895fb2f1859c42a6fa269473f150b9855c2e347ec-d: no space left on device"
```