### PR TITLE
chore: add shellcheck, actionlint, and gate fullsend on Go lint

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,21 @@
   "extends": [
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Pin actionlint version in workflow install step",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/pr\\.yml$/"
+      ],
+      "matchStrings": [
+        "ACTIONLINT_VERSION:\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "rhysd/actionlint",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ],
   "tekton": {
     "enabled": true,
     "automergeType": "pr",

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -20,6 +20,7 @@ name: fullsend
 permissions:
   actions: write
   id-token: write
+  checks: read
   contents: read
   pull-requests: read
 
@@ -34,13 +35,36 @@ on:
     types: [submitted]
 
 jobs:
+  wait-for-go-lint:
+    if: >-
+      github.event_name == 'pull_request_target'
+      && contains(fromJSON('["opened","synchronize","ready_for_review"]'), github.event.action)
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      pull-requests: read
+    steps:
+      - name: Wait for Lint Go
+        uses: lewagon/wait-on-check-action@96d9100b431964d10e0136aff8b9ccb92470505e # v1.8.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: "Lint Go"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
+          checks-discovery-timeout: 600
+
   dispatch:
+    needs: wait-for-go-lint
     concurrency:
       group: fullsend-dispatch-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
     if: >-
-      github.event_name != 'issue_comment'
-      || github.event.comment.user.type != 'Bot'
+      always()
+      && (needs.wait-for-go-lint.result == 'success' || needs.wait-for-go-lint.result == 'skipped')
+      && (
+        github.event_name != 'issue_comment'
+        || github.event.comment.user.type != 'Bot'
+      )
     uses: konflux-ci/.fullsend/.github/workflows/dispatch.yml@ec21706cccc58d01588ecd842464a5afcc375ba1 # main
     with:
       event_action: ${{ github.event.action }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check go mod status
         run: |
           go mod tidy
-          if [[ ! -z $(git status -s) ]]
+          if [[ -n $(git status -s) ]]
           then
             echo "Go mod state is not clean:"
             git --no-pager diff
@@ -43,7 +43,7 @@ jobs:
       - name: Check format
         run: |
           make fmt
-          if [[ ! -z $(git status -s) ]]
+          if [[ -n $(git status -s) ]]
           then
             echo "Some files are not properly formatted."
             echo "Please run 'make fmt' and amend your commit."
@@ -53,7 +53,7 @@ jobs:
       - name: Check manifests
         run: |
           make generate manifests
-          if [[ ! -z $(git status -s) ]]
+          if [[ -n $(git status -s) ]]
           then
             echo "Generated sources are not up to date:"
             git --no-pager diff
@@ -61,7 +61,7 @@ jobs:
           fi
       - name: Check RBAC wildcards
         run: |
-          if grep -n "*" config/rbac/*.yaml ; then
+          if grep -Fn '*' config/rbac/*.yaml ; then
             echo "RBAC files contain wildcards (*)"
             exit 1
           fi
@@ -91,6 +91,31 @@ jobs:
           version: v0.7.6
           directory: config
           config: .kube-linter.yaml
+
+  workflow-lint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install shellcheck and actionlint
+        env:
+          # Renovate: customManagers in .github/renovate.json
+          ACTIONLINT_VERSION: 1.7.7
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL -o "${archive}" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          tar xzf "${archive}"
+          sudo install -m 755 actionlint /usr/local/bin/actionlint
+
+      - name: Run actionlint
+        run: make actionlint
 
   agent:
     name: Agent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Run from the repository root. See `make help` for every target.
 | `make fmt` | Runs `go fmt ./...` on all packages. CI fails if code is not formatted. |
 | `make vet` | Runs `go vet ./...` for static analysis. |
 | `make lint` | Runs `golangci-lint` using the `.golangci.yaml` config file on the repository. |
+| `make actionlint` | Lints `.github/workflows/` (including inline `run:` shell when `shellcheck` is installed). |
 | `make generate` | Regenerates DeepCopy methods (`controller-gen object`); needed after API type changes. Output includes `zz_generated.deepcopy.go` files — do not edit. |
 | `make manifests` | Regenerates CRD YAML under `config/crd/bases/` and RBAC under `config/rbac/` from kubebuilder markers and API types — do not edit generated YAML files. |
 | `make test` | Runs `manifests`, `generate`, `fmt`, `vet`, then unit and integration tests with **envtest** (downloads kubebuilder assets for `ENVTEST_K8S_VERSION` in the Makefile). Produces `cover.out`. |

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,16 @@ lint: golangci-lint ## Run golangci-lint linter
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
 
+ACTIONLINT ?= actionlint
+
+.PHONY: actionlint
+actionlint: ## Lint GitHub Actions workflows (including inline run: shell)
+	@set -e; \
+	for f in .github/workflows/*; do \
+		$(ACTIONLINT) "$$f"; \
+		echo "$$f - ok"; \
+	done
+
 ##@ Build
 
 .PHONY: build

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,6 +13,7 @@ Match CI and the Makefile:
 | kubectl            | Compatible with your cluster                                                                        |
 | Container tool     | **Podman** by default (`CONTAINER_TOOL ?= podman`); Docker works if you set `CONTAINER_TOOL=docker` |
 | make               | Standard developer workflow                                                                         |
+| actionlint         | Optional locally; required in CI (`make actionlint`)                                                |
 
 For local deployment you need cluster-admin or sufficient RBAC to install CRDs and deploy the manager.
 
@@ -87,14 +88,18 @@ make docker-build docker-push IMG=<registry>/mintmaker:<tag>
 
 # E2E (requires a Kubernetes cluster):
 make test-e2e
+
+# GH Actions workflow linting (also run in CI; needs actionlint on PATH;
+# shellcheck optional but enables inline run: shell checks):
+make actionlint   # .github/workflows/
 ```
 
-CI (`[.github/workflows/pr.yml](../.github/workflows/pr.yml)`) runs the `Lint` job first (go mod tidy, `make fmt`, `make generate manifests`, RBAC wildcard check, `make lint`, markdownlint, kube-linter), then `Test Go` (`make test`, `make build`, Codecov) only after lint passes. The `Agent` job checks AGENTS.md line count in parallel.
+CI (`[.github/workflows/pr.yml](../.github/workflows/pr.yml)`) runs `Lint Go` (go mod tidy, `make fmt`, `make generate manifests`, RBAC wildcard check, `make lint`), then `Test Go` (`make test`, `make build`, Codecov) only after that job passes. In parallel: `Lint Markdown`, `Lint Kubernetes manifests`, `Lint workflows` (actionlint on `.github/workflows/`, including inline `run:` shell when shellcheck is installed), and `Agent` (AGENTS.md line count).
 
 ## Before opening a pull request
 
 ```sh
-make fmt generate manifests lint test build
+make fmt generate manifests lint actionlint test build
 ```
 
 We welcome contributions via pull requests and issues. Maintainers: [.github/CODEOWNERS](../.github/CODEOWNERS) (`@konflux-ci/mintmaker-maintainers`).


### PR DESCRIPTION
Add hack/shellcheck-embedded-tekton-scripts to extract Tekton Script: strings from pipeline_run_builder.go to be able to run shellcheck on those scripts.

Add a shellcheck to the go-lint CI job (check the shell scripts in PLR builder).

Add actionlint CI check to lint github workflows.

Gate fullsend dispatch on pull_request_target until the Lint Go and PLR shell scripts check passes.

Fix RBAC wildcard grep (grep -Fn) and replace `! -z` with `-n` (these were flagged by the actionlint).

Tests were not implemented for the new `.go` file under hack, because it has no functional effect on the MintMaker controller (it is purely for shellcheck purposes).

Changes are done based on: [CWFHEALTH-5019](https://redhat.atlassian.net/browse/CWFHEALTH-5019)

[CWFHEALTH-5019]: https://redhat.atlassian.net/browse/CWFHEALTH-5019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


edit:
- shellcheck of tekton pipeline `run` scripts was dropped - too high maintanance cost for little benefit
- added renovate custom regex manager to update actionlint version