### PR TITLE
fix: add codecov ignore patterns for non-executable files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,6 +18,12 @@ ignore:
   - "api/v1alpha1/dependencyupdatecheck_types.go"
   - "**/mock_*.go"
   - "cmd/"
+  - ".github/**"
+  - "**/*.yml"
+  - "**/*.yaml"
+  - "**/*.toml"
+  - "**/*.sh"
+  - "**/*.md"
 
 flags:
   unit-tests:


### PR DESCRIPTION
## Problem

PR #549 added golangci-lint YAML config files which Codecov counted as uncovered patch lines, contributing to the Mintmaker team patch coverage dropping to 47.1%.

Codecov cannot instrument YAML/config/markdown files — they will always appear as 0% covered, artificially depressing patch coverage metrics whenever CI infrastructure changes are merged.

## Fix

Add ignore patterns to `codecov.yml` for file types that cannot be unit tested:
- `.github/**` — GitHub Actions workflows
- `**/*.yml` / `**/*.yaml` — YAML config files
- `**/*.toml` — TOML config files
- `**/*.sh` — Shell scripts
- `**/*.md` — Documentation

Note: This PR addresses the config file noise in patch coverage. The deleted `suite_util_test.go` helpers and untested `osv-downloader` code are separate issues that require actual test additions.