### PR TITLE
Use semver-coerced versioning for Konflux tasks

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -107,6 +107,7 @@
           "/^quay.io/konflux-ci/tekton-catalog//"
         ],
         "enabled": true,
+        "versioning": "semver-coerced",
         "groupName": "Konflux references",
         "branchPrefix": "konflux/references/",
         "additionalBranchPrefix": "",


### PR DESCRIPTION
Konflux tasks are starting to use proper x.y.z semantic versioning. For some of them, that means they no longer use floating x.y tags to point to the latest x.y.z version, they only use the x.y.z tags.

By default, Renovate uses the docker [1] versioning strategy for tekton bundles, which never updates tags from x.y to x.y.z. That means users are stuck with e.g. the 0.2 version of a task even though the task has a newer 0.2.1 version.

Use semver-coerced [2] instead, which treats x.y as x.y.0. This supports both the floating tag style of task versioning and the new x.y.z style. For tasks that don't use x.y.z tags yet, Renovate will continue to update the digest when the floating tag moves. For tasks that do, Renovate will update from x.y to x.y.z (if z > 0).

Limit this to Konflux tasks (quay.io/konflux-ci/tekton-catalog/*) rather
than applying to the tekton manager as a whole.

[1]: https://docs.renovatebot.com/modules/versioning/docker/
[2]: https://docs.renovatebot.com/modules/versioning/semver-coerced/