### PR TITLE
Remove links to migration docs for Konflux tekton tasks

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -115,15 +115,6 @@
           "commitMessageTopic": "{{{groupName}}}"
         },
         "commitMessageTopic": "Konflux references",
-        "prBodyColumns": [
-          "Package",
-          "Change",
-          "Notes"
-        ],
-        "prBodyDefinitions": {
-          "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration]({{{sourceUrl}}}/blob/main/task/{{{replace '^quay.io/(redhat-appstudio-tekton-catalog|konflux-ci/tekton-catalog)/task-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}"
-        },
-        "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
         "recreateWhen": "always",
         "rebaseWhen": "behind-base-branch"
       },


### PR DESCRIPTION
This has been superseded by having actual release notes. The migrations docs themselves are no longer maintained and they won't work for patch versions (in semver).

This change will use the same table layout like all other PRs, thus unifying the user experience and bringing us closer to the default config.

**Before**
<img width="1053" height="429" alt="Screenshot From 2026-07-14 13-37-08" src="https://github.com/user-attachments/assets/04550998-611f-4e29-b276-ee74e3f20dae" />

**After**
<img width="1053" height="429" alt="Screenshot From 2026-07-14 13-34-38" src="https://github.com/user-attachments/assets/85ac45c0-a05a-4a8e-b807-b2951bf365d2" />

cc @chmeliik 