### PR TITLE
Enable dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "helpers:pinGitHubActionDigestsToSemver"
+    "helpers:pinGitHubActionDigestsToSemver",
+    ":dependencyDashboard"
   ],
   "customManagers": [
     {


### PR DESCRIPTION
I'd like to enable the dashboard because it contains helpful information that might sometimes be found only in logs.