### PR TITLE
Explicitly enable dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "helpers:pinGitHubActionDigestsToSemver",
-    ":dependencyDashboard"
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "dependencyDashboard": true,
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Since we added that preset to ignorePresets, adding it won't work.