### PR TITLE
Bump Go to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:0b0dd6f4ee311854a6b8e18b3bc52e7aa6b66f935a16c8f9bda173353ab16c64 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konflux-ci/mintmaker
 
-go 1.25.7
+go 1.26.5
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0


### PR DESCRIPTION
This fixes CVE-2026-39820 and CVE-2026-42499