### PR TITLE
Update codecov.yml: add ignore patterns for non-code dirs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -24,6 +24,11 @@ ignore:
   - "**/*.toml"
   - "**/*.sh"
   - "**/*.md"
+  - ".agents/**"
+  - ".claude/**"
+  - ".cursor/**"
+  - "skills/**"
+  - "docs/**"
 
 flags:
   unit-tests:


### PR DESCRIPTION
## Summary

Adds ignore patterns for non-code directories that inflate the coverage denominator:

- `.agents/**` — AI agent configurations
- `.claude/**` — Claude AI workspace settings
- `.cursor/**` — Cursor AI settings
- `skills/**` — AI skill definitions
- `docs/**` — Documentation files

Existing ignore patterns (generated files, `*.md`, `*.toml`, `*.yml`, etc.) are preserved.

## Why

Non-executable files are counted as "uncovered lines" by Codecov, dragging down patch coverage even though they can't be tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)