### PR TITLE
KONFLUX-9132: renovate: allow update_artifacts_lockfile as postUpgradeTasks command

### DIFF
--- a/config/renovate/renovate.json
+++ b/config/renovate/renovate.json
@@ -642,7 +642,8 @@
   "allowedCommands": [
     "^rpm-lockfile-prototype rpms.in.yaml$",
     "^pipeline-migration-tool migrate -f \"\\$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\"$",
-    "^refresh-rpm-lockfiles -f \"\\$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\"$"
+    "^refresh-rpm-lockfiles -f \"\\$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\"$",
+    "^update_artifacts_lockfile .+$"
   ],
   "updateNotScheduled": false,
   "dependencyDashboard": false,


### PR DESCRIPTION
Add update_artifacts_lockfile to allowedCommands in config/renovate/self_hosted.json so MintMaker permits repos to call it from postUpgradeTasks.

Without this entry, MintMaker rejects the command even if the script is installed the allowlist is enforced server-side and cannot be overridden per-repo. The regex `^update_artifacts_lockfile .+$` requires a file path argument, preventing the command from being called without a target.

Depends on: https://github.com/konflux-ci/mintmaker-renovate-image/pull/539, the script must be installed in the image before this allowlist entry has any effect.

Closes: https://github.com/konflux-ci/mintmaker/issues/528
Related: https://redhat.atlassian.net/browse/KONFLUX-9132