### PR TITLE
Fix log sanitizer to include error messages in logs

### DIFF
--- a/internal/tekton/log_sanitizer.sh
+++ b/internal/tekton/log_sanitizer.sh
@@ -11,9 +11,11 @@ if [ ! -f "$LOG_FILE" ]; then
   exit 0
 fi
 echo 'Scanning log file for leaked secrets...'
-SCAN_OUTPUT=$(leaktk scan --kind JSONData "@${LOG_FILE}" 2>/dev/null)
+SCAN_STDERR=$(mktemp)
+trap 'rm -f "$SCAN_STDERR"' EXIT
+SCAN_OUTPUT=$(leaktk scan --kind JSONData "@${LOG_FILE}" 2>"$SCAN_STDERR")
 if [ $? -ne 0 ]; then
-  echo 'leaktk scan failed'
+  echo "leaktk scan failed: $(cat "$SCAN_STDERR")"
   fail_safe
 fi
 if [ -z "$SCAN_OUTPUT" ]; then

--- a/internal/tekton/log_sanitizer_test.go
+++ b/internal/tekton/log_sanitizer_test.go
@@ -79,14 +79,15 @@ var _ = Describe("log_sanitizer.sh", func() {
 	When("leaktk scan fails", func() {
 		BeforeEach(func() {
 			Expect(os.WriteFile(logFile, []byte(`{"some": "log"}`), 0600)).To(Succeed())
-			writeStub(mockDir, "leaktk", `echo "scan error" >&2; exit 1`)
+			writeStub(mockDir, "leaktk", `echo '{"results": [{"secret": "leaked-password"}]}'; echo "scan error" >&2; exit 1`)
 		})
 
-		It("should call fail_safe and overwrite the log file", func() {
+		It("should log the error but not the scan results", func() {
 			output, exitCode := runSanitizer(scriptFile, logFile, mockDir)
 
 			Expect(exitCode).To(Equal(0))
-			Expect(output).To(ContainSubstring("leaktk scan failed"))
+			Expect(output).To(ContainSubstring("leaktk scan failed: scan error"))
+			Expect(output).NotTo(ContainSubstring("leaked-password"))
 			logContent, err := os.ReadFile(logFile) //nolint:gosec // test assertion
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(logContent)).To(ContainSubstring("Sanitization step failed"))
@@ -153,11 +154,12 @@ var _ = Describe("log_sanitizer.sh", func() {
 			writeStub(mockDir, "python3", `echo "my-secret-value"`)
 		})
 
-		It("should redact the secret from the log file", func() {
+		It("should redact the secret from the log file and not leak it in step output", func() {
 			output, exitCode := runSanitizer(scriptFile, logFile, mockDir)
 
 			Expect(exitCode).To(Equal(0))
 			Expect(output).To(ContainSubstring("Log sanitization complete"))
+			Expect(output).NotTo(ContainSubstring("my-secret-value"))
 			logContent, err := os.ReadFile(logFile) //nolint:gosec // test assertion
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(logContent)).To(Equal(`{"msg": "token **REDACTED** here"}`))


### PR DESCRIPTION
Previously, if the leatktk step failed, the specific error message was not included in the logs of that step, which hinders debugging.

This commit changes the logging logic, to make sure the error message is included in the logs, and updates the tests to ensure the correct behavior.