### PR TITLE
Fix sanitizer handling of input data

### DIFF
--- a/internal/tekton/log_sanitizer.sh
+++ b/internal/tekton/log_sanitizer.sh
@@ -13,7 +13,7 @@ fi
 echo 'Scanning log file for leaked secrets...'
 SCAN_STDERR=$(mktemp)
 trap 'rm -f "$SCAN_STDERR"' EXIT
-SCAN_OUTPUT=$(leaktk scan --kind JSONData "@${LOG_FILE}" 2>"$SCAN_STDERR")
+SCAN_OUTPUT=$(leaktk scan --kind Text "@${LOG_FILE}" 2>"$SCAN_STDERR")
 if [ $? -ne 0 ]; then
   echo "leaktk scan failed: $(cat "$SCAN_STDERR")"
   fail_safe

--- a/internal/tekton/log_sanitizer_test.go
+++ b/internal/tekton/log_sanitizer_test.go
@@ -76,6 +76,26 @@ var _ = Describe("log_sanitizer.sh", func() {
 		})
 	})
 
+	When("leaktk scan succeeds", func() {
+		BeforeEach(func() {
+			Expect(os.WriteFile(logFile, []byte(`{"some": "log"}`), 0600)).To(Succeed())
+			// Record the arguments leaktk was invoked with so we can assert the
+			// script scans the NDJSON log as plain text (--kind Text), not as a
+			// single JSON document (--kind JSONData), which fails on Renovate's
+			// newline-delimited JSON output.
+			writeStub(mockDir, "leaktk", `echo "$@" > "`+filepath.Join(tmpDir, "leaktk-args")+`"`)
+		})
+
+		It("should invoke leaktk with --kind Text", func() {
+			_, exitCode := runSanitizer(scriptFile, logFile, mockDir)
+
+			Expect(exitCode).To(Equal(0))
+			args, err := os.ReadFile(filepath.Join(tmpDir, "leaktk-args")) //nolint:gosec // test assertion
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(args)).To(ContainSubstring("scan --kind Text"))
+		})
+	})
+
 	When("leaktk scan fails", func() {
 		BeforeEach(func() {
 			Expect(os.WriteFile(logFile, []byte(`{"some": "log"}`), 0600)).To(Succeed())
@@ -148,8 +168,14 @@ var _ = Describe("log_sanitizer.sh", func() {
 	})
 
 	When("secrets are found", func() {
+		// Renovate emits newline-delimited JSON (NDJSON), not a single JSON
+		// document. The secret sits on one line among several.
+		ndjson := `{"level":30,"msg":"starting"}
+{"level":30,"msg":"token my-secret-value here"}
+{"level":30,"msg":"done"}`
+
 		BeforeEach(func() {
-			Expect(os.WriteFile(logFile, []byte(`{"msg": "token my-secret-value here"}`), 0600)).To(Succeed())
+			Expect(os.WriteFile(logFile, []byte(ndjson), 0600)).To(Succeed())
 			writeStub(mockDir, "leaktk", `echo '{"results": [{"secret": "my-secret-value"}]}'`)
 			writeStub(mockDir, "python3", `echo "my-secret-value"`)
 		})
@@ -162,7 +188,9 @@ var _ = Describe("log_sanitizer.sh", func() {
 			Expect(output).NotTo(ContainSubstring("my-secret-value"))
 			logContent, err := os.ReadFile(logFile) //nolint:gosec // test assertion
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(logContent)).To(Equal(`{"msg": "token **REDACTED** here"}`))
+			Expect(string(logContent)).To(Equal(`{"level":30,"msg":"starting"}
+{"level":30,"msg":"token **REDACTED** here"}
+{"level":30,"msg":"done"}`))
 			Expect(string(logContent)).NotTo(ContainSubstring("my-secret-value"))
 		})
 	})


### PR DESCRIPTION
The sanitization step was failing because it was invoked with the wrong flag, which caused it to fail parsing renovate's NDJSON logs.

This commit changes the invokation flag to "Text", so leaktk treats the input as arbitraty text, and don't expect the input to be a JSON (which wasn't the case, it was actually NDJSON).

There is also a guardrail test to catch regressions of the flag, and a minor adjustment in the test data to reflect renovate's actual data format.

Assisted-by: Claude Opus 4.8