### PR TITLE
fix(refresh-rpm-lockfiles): Increase executionTimout for as a temp so…

### DIFF
--- a/config/renovate/self_hosted.json
+++ b/config/renovate/self_hosted.json
@@ -3,6 +3,7 @@
   "redisPrefix": "renovate-global-cache",
   "redisUrl": "redis://redis:6379",
   "allowShellExecutorForPostUpgradeCommands": true,
+  "executionTimeout": 25,
   "customEnvVariables": {
     "GOCACHE": "/tmp/go-build-cache",
     "GOTOOLCHAIN": "auto",


### PR DESCRIPTION
…lution

By default renovate has 15 mins timeout for its child processes. Increasing it  to 25 mins as a temporary solution to avoid the SIGTERM signal for refresh-rpm-lockfiles command for repos with >15 dockerfiles. A new solution is being implemented to optimize refresh-rpm-lockfiles. 

Jira:  CWFHEALTH-5092